### PR TITLE
Add `npmPublish` and `tarballDir` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ Determine the last release of the package on the `npm` registry.
 
 ## publish
 
-Publish the package on the `npm` registry.
+Update the `package.json` version, [create](https://docs.npmjs.com/cli/pack) the `npm` package tarball and [publish](https://docs.npmjs.com/cli/publish) to the `npm` registry.
 
 ## Configuration
 
-### Environment variables
+### Npm registry authentication
 
-The `npm` authentication configuration is **required** and can be set via environment variables.
+The `npm` authentication configuration is **required** and can be set via [environment variables](#environment-variables).
 
 Both the [token](https://docs.npmjs.com/getting-started/working_with_tokens) and the legacy (`username`, `password` and `email`) authentication are supported. It is recommended to use the [token](https://docs.npmjs.com/getting-started/working_with_tokens) authentication. The legacy authentication is supported as the alternative npm registries [Artifactory](https://www.jfrog.com/open-source/#os-arti) and [npm-registry-couchapp](https://github.com/npm/npm-registry-couchapp) only supports that form of authentication at this point.
 
-| Variable       | Description                                              
+### Environment variables
+
+| Variable       | Description                                                                                                                   |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `NPM_TOKEN`    | Npm token created via [npm token create](https://docs.npmjs.com/getting-started/working_with_tokens#how-to-create-new-tokens) |
 | `NPM_USERNAME` | Npm username created via [npm adduser](https://docs.npmjs.com/cli/adduser) or on [npmjs.com](https://www.npmjs.com)           |
@@ -36,6 +38,13 @@ Both the [token](https://docs.npmjs.com/getting-started/working_with_tokens) and
 Use either `NPM_TOKEN` for token authentication or `NPM_USERNAME`, `NPM_PASSWORD` and `NPM_EMAIL` for legacy authentication
 
 ### Options
+
+| Options      | Description                                                                                                            | Default |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- | ------- |
+| `npmPublish` | Whether to publish the `npm` package to the registry. If `false` the `package.json` version will still be updated.     | `true`  |
+| `tarballDir` | Directory path in which to generate the the package tarball. If `false` the tarball is not be kept on the file system. | `false` |
+
+### Npm configuration
 
 The plugins are based on `npm` and will use the configuration from [`.npmrc`](https://docs.npmjs.com/files/npmrc). See [npm config](https://docs.npmjs.com/misc/config) for the option list.
 
@@ -54,12 +63,35 @@ The [`registry`](https://docs.npmjs.com/misc/registry) and [`dist-tag`](https://
 The plugins are used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no specific configuration is requiered to use them.
 
 Each individual plugin can be disabled, replaced or used with other plugins in the `package.json`:
+
 ```json
 {
   "release": {
     "verifyConditions": ["@semantic-release/npm", "verify-other-condition"],
     "getLastRelease": "custom-get-last-release",
     "publish": ["@semantic-release/npm", "custom-publish"]
+  }
+}
+```
+
+The `npmPublish` and `tarballDir` option can be used to skip the publishing to the `npm` registry and instead, release the package tarball with another plugin. For example with the [github](https://github.com/semantic-release/github):
+
+```json
+{
+  "release": {
+    "verifyConditions": ["@semantic-release/conditions-travis", "@semantic-release/npm", "@semantic-release/git", "@semantic-release/github"],
+    "getLastRelease": "@semantic-release/git",
+    "publish": [
+      {
+        "path": "@semantic-release/npm",
+        "npmPublish": false,
+        "tarballDir": "dist"
+      },
+      {
+        "path": "@semantic-release/github",
+        "assets": "dist/*.tgz"
+      },
+    ]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const {castArray} = require('lodash');
 const setLegacyToken = require('./lib/set-legacy-token');
 const getPkg = require('./lib/get-pkg');
 const verifyNpm = require('./lib/verify');
@@ -6,10 +7,22 @@ const getLastReleaseNpm = require('./lib/get-last-release');
 
 let verified;
 
-async function verifyConditions(pluginConfig, {logger}) {
+async function verifyConditions(pluginConfig, {options, logger}) {
+  // If the npm publish plugin is used and has `npmPublish` or `tarballDir` configured, validate them now in order to prevent any release if the configuration is wrong
+  if (options.publish) {
+    const publishPlugin = castArray(options.publish).find(
+      config => config.path && config.path === '@semantic-release/npm'
+    );
+    if (publishPlugin && publishPlugin.npmPublish) {
+      pluginConfig.npmPublish = publishPlugin.npmPublish;
+    }
+    if (publishPlugin && publishPlugin.tarballDir) {
+      pluginConfig.tarballDir = publishPlugin.tarballDir;
+    }
+  }
   setLegacyToken();
   const pkg = await getPkg();
-  await verifyNpm(pkg, logger);
+  await verifyNpm(pluginConfig, pkg, logger);
   verified = true;
 }
 
@@ -18,7 +31,7 @@ async function getLastRelease(pluginConfig, {logger}) {
   // Reload package.json in case a previous external step updated it
   const pkg = await getPkg();
   if (!verified) {
-    await verifyNpm(pkg, logger);
+    await verifyNpm(pluginConfig, pkg, logger);
     verified = true;
   }
   return getLastReleaseNpm(pkg, logger);
@@ -29,10 +42,10 @@ async function publish(pluginConfig, {nextRelease: {version}, logger}) {
   // Reload package.json in case a previous external step updated it
   const pkg = await getPkg();
   if (!verified) {
-    await verifyNpm(pkg, logger);
+    await verifyNpm(pluginConfig, pkg, logger);
     verified = true;
   }
-  await publishNpm(pkg, version, logger);
+  await publishNpm(pluginConfig, pkg, version, logger);
 }
 
 module.exports = {verifyConditions, getLastRelease, publish};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,12 +1,22 @@
+const path = require('path');
+const {move} = require('fs-extra');
 const execa = require('execa');
 const getRegistry = require('./get-registry');
 const updatePackageVersion = require('./update-package-version');
 
-module.exports = async ({publishConfig, name}, version, logger) => {
+module.exports = async ({npmPublish, tarballDir}, {publishConfig, name}, version, logger) => {
   const registry = await getRegistry(publishConfig, name);
   await updatePackageVersion(version, logger);
 
-  logger.log('Publishing version %s to npm registry', version);
-  const shell = await execa('npm', ['publish', '--registry', registry]);
-  process.stdout.write(shell.stdout);
+  if (tarballDir) {
+    logger.log('Creating npm package version %s', version);
+    const tarball = await execa.stdout('npm', ['pack']);
+    await move(tarball, path.join(tarballDir.trim(), tarball));
+  }
+
+  if (npmPublish !== false) {
+    logger.log('Publishing version %s to npm registry', version);
+    const shell = await execa('npm', ['publish', '--registry', registry]);
+    process.stdout.write(shell.stdout);
+  }
 };

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,9 +1,18 @@
+const {isString, isUndefined, isBoolean} = require('lodash');
 const execa = require('execa');
 const SemanticReleaseError = require('@semantic-release/error');
 const getRegistry = require('./get-registry');
 const setNpmrcAuth = require('./set-npmrc-auth');
 
-module.exports = async (pkg, logger) => {
+module.exports = async ({npmPublish, tarballDir}, pkg, logger) => {
+  if (!isUndefined(npmPublish) && !isBoolean(npmPublish)) {
+    throw new SemanticReleaseError('The "npmPublish" options, if defined, must be a Boolean.', 'EINVALIDNPMPUBLISH');
+  }
+
+  if (!isUndefined(tarballDir) && !isString(tarballDir)) {
+    throw new SemanticReleaseError('The "tarballDir" options, if defined, must be a String.', 'EINVALIDTARBALLDIR');
+  }
+
   const registry = await getRegistry(pkg.publishConfig, pkg.name);
   await setNpmrcAuth(registry, logger);
   try {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@semantic-release/error": "^2.1.0",
     "execa": "^0.8.0",
     "fs-extra": "^4.0.2",
+    "lodash": "^4.17.4",
     "nerf-dart": "^1.0.0",
     "npm-conf": "^1.1.3",
     "npm-registry-client": "^8.5.0",

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import {stub} from 'sinon';
+import verify from '../lib/verify';
+
+test.beforeEach(t => {
+  // Stub the logger functions
+  t.context.log = stub();
+  t.context.logger = {log: t.context.log};
+});
+
+test('Throw SemanticReleaseError if "npmPublish" option is not a Boolean', async t => {
+  const npmPublish = 42;
+  const error = await t.throws(verify({npmPublish}, {}, t.context.logger));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDNPMPUBLISH');
+});
+
+test('Throw SemanticReleaseError if "tarballDir" option is not a String', async t => {
+  const tarballDir = 42;
+  const error = await t.throws(verify({tarballDir}, {}, t.context.logger));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDTARBALLDIR');
+});


### PR DESCRIPTION
Add 2 new options:
- `npmPublish` can be set to `false` to skip the publishing on npm registry
- If `tarballDir` is set the npm tarball (`npm pack`) will be generated in the configured directory

That will allow to users who do not want to publish on the registry to still use the plugin to:
- Update the `package.json` and publish it with [git]([npm](https://github.com/semantic-release/git)) or [github]([npm](https://github.com/semantic-release/github))
- To generate the npm tarball and publish it as well