### PR TITLE
fix: set LEGACY_TOKEN as auth

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -8,13 +8,15 @@ const getRegistry = require('./get-registry');
 module.exports = async ({publishConfig, name}, logger) => {
   const config = npmConf();
   const tag = (publishConfig || {}).tag || config.get('tag');
-  const {NPM_TOKEN, NPM_USERNAME, NPM_PASSWORD, NPM_EMAIL} = process.env;
+  const {NPM_TOKEN, NPM_USERNAME, NPM_PASSWORD, NPM_EMAIL, LEGACY_TOKEN} = process.env;
   const client = new RegClient(getClientConfig(config));
   const registry = await getRegistry(publishConfig, name);
 
   try {
     const uri = urlResolve(registry, name.replace('/', '%2F'));
-    const auth = NPM_TOKEN ? {token: NPM_TOKEN} : {username: NPM_USERNAME, password: NPM_PASSWORD, email: NPM_EMAIL};
+    const auth = NPM_TOKEN
+      ? {token: NPM_TOKEN}
+      : {username: NPM_USERNAME, password: NPM_PASSWORD, email: NPM_EMAIL, auth: LEGACY_TOKEN};
     auth.alwaysAuth = config.get('always-auth');
     const data = await promisify(client.get.bind(client))(uri, {auth});
     if (data && !data['dist-tags']) {


### PR DESCRIPTION
Fixes #13

Finally had a successful publish :D

The real fix might be to pull auth from `.npmrc`, but this works.

These are the overrides in my package.json:

```json
"resolutions": {
  "@semantic-release/condition-travis": "SimenB/condition-travis#db3fd849cdf2ad9162f2acdf5f409f9e82f5ac76",
  "@semantic-release/npm": "SimenB/npm-1#c5e894b513886a4fbceafc3532b55a5ef859f5bc",
  "travis-ci": "pwmckenna/node-travis-ci#39ad0c315e53bc360850994ebaf01f73dc14a18e"
}
```
The 2 travis ones are for support of Travis Enterprise, while the npm one is the commit in this PR.

This is a successful publish to Artifactory 4.16.0 from Travis Enterprise, publishing a release on GitHub Enterprise.