### PR TITLE
feat: get always-auth from scoped

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -4,6 +4,18 @@ const npmConf = require('npm-conf');
 const RegClient = require('npm-registry-client');
 const getClientConfig = require('./get-client-config');
 const getRegistry = require('./get-registry');
+const toNerfDart = require('./nerf-dart');
+
+function getAlwaysAuth(registry, config) {
+  const nerfed = toNerfDart(registry);
+  const registryAuth = config.get(`${nerfed}:always-auth`);
+
+  if (registryAuth !== undefined) {
+    return registryAuth;
+  }
+
+  return config.get('always-auth');
+}
 
 module.exports = async ({publishConfig, name}, logger) => {
   const config = npmConf();
@@ -15,7 +27,7 @@ module.exports = async ({publishConfig, name}, logger) => {
   try {
     const uri = urlResolve(registry, name.replace('/', '%2F'));
     const auth = NPM_TOKEN ? {token: NPM_TOKEN} : {username: NPM_USERNAME, password: NPM_PASSWORD, email: NPM_EMAIL};
-    auth.alwaysAuth = config.get('always-auth');
+    auth.alwaysAuth = getAlwaysAuth(registry, config);
     const data = await promisify(client.get.bind(client))(uri, {auth});
     if (data && !data['dist-tags']) {
       logger.log('No version found of package %s found on %s', name, registry);

--- a/lib/nerf-dart.js
+++ b/lib/nerf-dart.js
@@ -1,0 +1,25 @@
+// Copied from https://github.com/npm/npm/blob/0cc9d89ed2d46745f91d746fda9d205fd39d3daa/lib/config/nerf-dart.js
+
+const url = require('url');
+
+module.exports = toNerfDart;
+
+/**
+ * Maps a URL to an identifier.
+ *
+ * Name courtesy schiffertronix media LLC, a New Jersey corporation
+ *
+ * @param {String} uri The URL to be nerfed.
+ *
+ * @returns {String} A nerfed URL.
+ */
+function toNerfDart(uri) {
+  const parsed = url.parse(uri);
+  delete parsed.protocol;
+  delete parsed.auth;
+  delete parsed.query;
+  delete parsed.search;
+  delete parsed.hash;
+
+  return url.resolve(url.format(parsed), '.');
+}


### PR DESCRIPTION
As mentioned in #13, the npm client supports scoped configuration in npmrc. This PR ports that functionality over.

I opened up https://github.com/kevva/npm-conf/pull/10, but I'm not sure if it will be accepted