### PR TITLE
Retrieve gitHead from git tag if it's missing from the npm metadata

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -4,6 +4,7 @@ const npmConf = require('npm-conf');
 const RegClient = require('npm-registry-client');
 const getClientConfig = require('./get-client-config');
 const getRegistry = require('./get-registry');
+const getVersionHead = require('./get-version-head');
 
 module.exports = async ({publishConfig, name}, logger) => {
   const config = npmConf();
@@ -30,7 +31,9 @@ module.exports = async ({publishConfig, name}, logger) => {
       version = distTags.latest;
       logger.log('Found version %s of package %s with dist-tag %s', version, name, 'latest');
     }
-    return {version, gitHead: data.versions[version].gitHead};
+    // Due to npm/read-package-json#77  the gitHead is missing for some packages
+    // In such case attempt to retrieve the gitHead based on a git tag named after the version
+    return {version, gitHead: data.versions[version].gitHead || (await getVersionHead(version))};
   } catch (err) {
     if (err.statusCode === 404 || /not found/i.test(err.message)) {
       logger.log('No version found of package %s found on %s', name, registry);

--- a/lib/get-version-head.js
+++ b/lib/get-version-head.js
@@ -1,0 +1,20 @@
+const debug = require('debug')('semantic-release:npm');
+const {gitTagHead, unshallow} = require('./git');
+
+module.exports = async version => {
+  let tagHead = (await gitTagHead(`v${version}`)) || (await gitTagHead(version));
+
+  // Check if tagHead is found
+  if (tagHead) {
+    debug('Use tagHead: %s', tagHead);
+    return tagHead;
+  }
+  await unshallow();
+
+  // Check if tagHead is found
+  tagHead = (await gitTagHead(`v${version}`)) || (await gitTagHead(version));
+  if (tagHead) {
+    debug('Use tagHead: %s', tagHead);
+    return tagHead;
+  }
+};

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,27 @@
+const execa = require('execa');
+const debug = require('debug')('semantic-release:npm');
+
+/**
+ * Get the commit sha for a given tag.
+ *
+ * @param {string} tagName Tag name for which to retrieve the commit sha.
+ *
+ * @return {string} The commit sha of the tag in parameter or `null`.
+ */
+async function gitTagHead(tagName) {
+  try {
+    return await execa.stdout('git', ['rev-list', '-1', tagName]);
+  } catch (err) {
+    debug(err);
+    return null;
+  }
+}
+
+/**
+ * Unshallow the git repository (retriving every commits and tags).
+ */
+async function unshallow() {
+  await execa('git', ['fetch', '--unshallow', '--tags'], {reject: false});
+}
+
+module.exports = {gitTagHead, unshallow};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@semantic-release/error": "^2.1.0",
+    "debug": "^3.1.0",
     "execa": "^0.8.0",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.4",
@@ -36,6 +37,7 @@
     "dockerode": "^2.5.3",
     "eslint-config-prettier": "^2.5.0",
     "eslint-plugin-prettier": "^2.3.0",
+    "file-url": "^2.0.2",
     "get-stream": "^3.0.0",
     "got": "^8.0.0",
     "nock": "^9.1.0",

--- a/test/get-version-head.test.js
+++ b/test/get-version-head.test.js
@@ -1,0 +1,49 @@
+import test from 'ava';
+import getVersionHead from '../lib/get-version-head';
+import {gitRepo, gitCommit, gitTagVersion, gitShallowClone} from './helpers/git-utils';
+
+// Save the current working diretory
+const cwd = process.cwd();
+
+test.afterEach.always(() => {
+  // Restore the current working directory
+  process.chdir(cwd);
+});
+
+test.serial('Get the commit sha for corresponding the version', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  // Add commits to the master branch
+  const commit = await gitCommit('First');
+  // Create the tag corresponding to version 1.0.0
+  await gitTagVersion('1.0.0');
+
+  t.is((await getVersionHead('1.0.0')).substring(0, 7), commit.hash);
+});
+
+test.serial('Get the commit sha for corresponding the version (starting with v)', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  // Add commits to the master branch
+  const commit = await gitCommit('First');
+  // Create the tag corresponding to version 1.0.0
+  await gitTagVersion('v1.0.0');
+
+  t.is((await getVersionHead('1.0.0')).substring(0, 7), commit.hash);
+});
+
+test.serial('Get the commit sha for corresponding the version on a shallow repository', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  const repo = await gitRepo();
+  // Add commits to the master branch
+  const commit = await gitCommit('First');
+  // Create the tag corresponding to version 1.0.0
+  await gitTagVersion('1.0.0');
+  // Add additionnal commits
+  await gitCommit('Second');
+  await gitCommit('Third');
+  // Create a shallow clone with only 1 commit
+  await gitShallowClone(repo);
+
+  t.is((await getVersionHead('1.0.0')).substring(0, 7), commit.hash);
+});

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -1,0 +1,49 @@
+import test from 'ava';
+import {gitTagHead, unshallow} from '../lib/git';
+import {gitRepo, gitCommit, gitTagVersion, gitShallowClone, gitLog} from './helpers/git-utils';
+
+// Save the current working diretory
+const cwd = process.cwd();
+
+test.afterEach.always(() => {
+  // Restore the current working directory
+  process.chdir(cwd);
+});
+
+test.serial('Get the commit sha for a given tag or "null" if the tag does not exists', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  // Add commits to the master branch
+  const commit = await gitCommit('First');
+  // Create the tag corresponding to version 1.0.0
+  await gitTagVersion('v1.0.0');
+
+  t.is((await gitTagHead('v1.0.0')).substring(0, 7), commit.hash);
+  t.falsy(await gitTagHead('missing_tag'));
+});
+
+test.serial('Unshallow repository', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  const repo = await gitRepo();
+  // Add commits to the master branch
+  await gitCommit('First');
+  await gitCommit('Second');
+  // Create a shallow clone with only 1 commit
+  await gitShallowClone(repo);
+
+  // Verify the shallow clone contains only one commit
+  t.is((await gitLog()).length, 1);
+
+  await unshallow();
+
+  // Verify the shallow clone contains all the commits
+  t.is((await gitLog()).length, 2);
+});
+
+test.serial('Do not throw error when unshallow a complete repository', async t => {
+  // Create a git repository, set the current working directory at the root of the repo
+  await gitRepo();
+  // Add commits to the master branch
+  await gitCommit('First');
+  await t.notThrows(unshallow());
+});

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -1,0 +1,83 @@
+import tempy from 'tempy';
+import fileUrl from 'file-url';
+import execa from 'execa';
+
+/**
+ * Create a temporary git repository and change the current working directory to the repository root.
+ *
+ * @return {string} The path of the repository.
+ */
+export async function gitRepo() {
+  const dir = tempy.directory();
+
+  process.chdir(dir);
+  await execa('git', ['init']);
+  await gitCheckout('master');
+  return dir;
+}
+
+/**
+ * Checkout a branch on the current git repository.
+ *
+ * @param {string} branch Branch name.
+ * @param {boolean} create `true` to create the branche ans switch, `false` to only switch.
+ */
+export async function gitCheckout(branch, create = true) {
+  await execa('git', create ? ['checkout', '-b', branch] : ['checkout', branch]);
+}
+
+/**
+ * Create commit on the current git repository.
+ *
+ * @param {String} message commit message.
+ *
+ * @returns {Commit} The created commits.
+ */
+export async function gitCommit(message) {
+  const {stdout} = await execa('git', ['commit', '-m', message, '--allow-empty', '--no-gpg-sign']);
+  const [, branch, hash] = /^\[(\w+)\(?.*?\)?(\w+)\] .+(?:\n|$)/.exec(stdout);
+  return {branch, hash, message};
+}
+
+/**
+ * Create a tag on the head commit in the current git repository.
+ *
+ * @param {string} tagName The tag name to create.
+ * @param {string} [sha] The commit on which to create the tag. If undefined the tag is created on the last commit.
+ *
+ * @return {string} The commit sha of the created tag.
+ */
+export async function gitTagVersion(tagName, sha) {
+  await execa('git', sha ? ['tag', '-f', tagName, sha] : ['tag', tagName]);
+  return (await execa('git', ['rev-list', '-1', '--tags', tagName])).stdout;
+}
+
+/**
+ * Create a shallow clone of a git repository and change the current working directory to the cloned repository root.
+ * The shallow will contain a limited number of commit and no tags.
+ *
+ * @param {string} origin The path of the repository to clone.
+ * @param {number} [depth=1] The number of commit to clone.
+ * @return {string} The path of the cloned repository.
+ */
+export async function gitShallowClone(origin, branch = 'master', depth = 1) {
+  const dir = tempy.directory();
+
+  process.chdir(dir);
+  await execa('git', ['clone', '--no-hardlinks', '--no-tags', '-b', branch, '--depth', depth, fileUrl(origin), dir]);
+  return dir;
+}
+
+/**
+ * @return {Array<string>} The list of commit sha from the current git repository.
+ */
+export async function gitLog() {
+  return (await execa('git', ['log', '--format=format:%H'])).stdout.split('\n').filter(sha => Boolean(sha));
+}
+
+/**
+ * Pack heads and tags of the current git repository.
+ */
+export async function gitPackRefs() {
+  await execa('git', ['pack-refs', '--all']);
+}


### PR DESCRIPTION
This is a port of a workaround for npm/read-package-json#77  implemented in the core when npm publishing was still part of it.

Now that we handle `npm` via plugin this npm specific workaround should be here.

In addition this will have to be used within this plugin to implement semantic-release/semantic-release#563