### PR TITLE
doc: clarify npm 2FA supported level

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The `npm` authentication configuration is **required** and can be set via [envir
 
 Both the [token](https://docs.npmjs.com/getting-started/working_with_tokens) and the legacy (`username`, `password` and `email`) authentication are supported. It is recommended to use the [token](https://docs.npmjs.com/getting-started/working_with_tokens) authentication. The legacy authentication is supported as the alternative npm registries [Artifactory](https://www.jfrog.com/open-source/#os-arti) and [npm-registry-couchapp](https://github.com/npm/npm-registry-couchapp) only supports that form of authentication at this point.
 
+**Note**: Only the `auth-only` [level of npm two-factor authentication](https://docs.npmjs.com/getting-started/using-two-factor-authentication#levels-of-authentication) is supported, semantic-release will not work with the default `auth-and-writes` level.
+
 ### Environment variables
 
 | Variable       | Description                                                                                                                   |


### PR DESCRIPTION
Closes #30.

Should I send a similar PR to the main semantic-release docs?