### PR TITLE
fix: get tarball name as last line from stdout

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,7 +11,7 @@ module.exports = async ({npmPublish, tarballDir, pkgRoot}, {publishConfig, name}
 
   if (tarballDir) {
     logger.log('Creating npm package version %s', version);
-    const tarball = await execa.stdout('npm', ['pack', `./${basePath}`]);
+    const tarball = (await execa.stdout('npm', ['pack', `./${basePath}`])).split('\n').pop();
     await move(tarball, path.join(tarballDir.trim(), tarball));
   }
 


### PR DESCRIPTION
some packages, for example [`patch-package`](https://github.com/ds300/patch-package), can print output while `prepare` task, so in order to get right tarball name it's better to get only last line from stdout 