### PR TITLE
feat: Add support for registry configuration

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,10 +2,10 @@ const execa = require('execa');
 const getRegistry = require('./get-registry');
 const getReleaseInfo = require('./get-release-info');
 
-module.exports = async ({npmPublish, pkgRoot}, {publishConfig, name}, version, logger) => {
+module.exports = async ({npmPublish, pkgRoot, registry}, {publishConfig, name}, version, logger) => {
   if (npmPublish !== false) {
     const basePath = pkgRoot || '.';
-    const registry = await getRegistry(publishConfig, name);
+    const registry = registry || await getRegistry(publishConfig, name);
     logger.log('Publishing version %s to npm registry', version);
     const shell = await execa('npm', ['publish', `./${basePath}`, '--registry', registry]);
     process.stdout.write(shell.stdout);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -5,7 +5,7 @@ const getReleaseInfo = require('./get-release-info');
 module.exports = async ({npmPublish, pkgRoot, registry: _registry}, {publishConfig, name}, version, logger) => {
   if (npmPublish !== false) {
     const basePath = pkgRoot || '.';
-    const registry = _registry || await getRegistry(publishConfig, name);
+    const registry = _registry || (await getRegistry(publishConfig, name));
     logger.log('Publishing version %s to npm registry', version);
     const shell = await execa('npm', ['publish', `./${basePath}`, '--registry', registry]);
     process.stdout.write(shell.stdout);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,10 +2,10 @@ const execa = require('execa');
 const getRegistry = require('./get-registry');
 const getReleaseInfo = require('./get-release-info');
 
-module.exports = async ({npmPublish, pkgRoot, registry}, {publishConfig, name}, version, logger) => {
+module.exports = async ({npmPublish, pkgRoot, registry: _registry}, {publishConfig, name}, version, logger) => {
   if (npmPublish !== false) {
     const basePath = pkgRoot || '.';
-    const registry = registry || await getRegistry(publishConfig, name);
+    const registry = _registry || await getRegistry(publishConfig, name);
     logger.log('Publishing version %s to npm registry', version);
     const shell = await execa('npm', ['publish', `./${basePath}`, '--registry', registry]);
     process.stdout.write(shell.stdout);


### PR DESCRIPTION
With this change an user is going to be able to define a custom registry for npm without having to edit its `package.json`.

This is especially useful in conjunction with `semantic-release-monorepo`, because it allows to define the custom registry in the root configuration and have it applied to all the monorepo packages.

Fixes #61