### PR TITLE
feat: preserve indentation and newline type of package.json

### DIFF
--- a/lib/update-package-version.js
+++ b/lib/update-package-version.js
@@ -1,24 +1,34 @@
 const path = require('path');
-const {readJson, writeJson, pathExists} = require('fs-extra');
+const parseJson = require('parse-json');
+const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const {readFile, writeJson, pathExists} = require('fs-extra');
+
+const DEFAULT_INDENT = 2;
+const DEFAULT_NEWLINE = '\n';
 
 module.exports = async (version, basePath, logger) => {
   const packagePath = path.join(basePath, 'package.json');
   const shrinkwrapPath = path.join(basePath, 'npm-shrinkwrap.json');
   const packageLockPath = path.join(basePath, 'package-lock.json');
-  const pkg = await readJson(packagePath);
+  const pkg = await readFile(packagePath, 'utf8');
 
-  await writeJson(packagePath, {...pkg, ...{version}}, {spaces: 2});
+  await writeJson(packagePath, {...parseJson(pkg), ...{version}}, getWriteOptions(pkg));
   logger.log('Wrote version %s to %s', version, packagePath);
 
   if (await pathExists(shrinkwrapPath)) {
-    const shrinkwrap = await readJson(shrinkwrapPath);
-    await writeJson(shrinkwrapPath, {...shrinkwrap, ...{version}}, {spaces: 2});
+    const shrinkwrap = await readFile(shrinkwrapPath, 'utf8');
+    await writeJson(shrinkwrapPath, {...parseJson(shrinkwrap), ...{version}}, getWriteOptions(shrinkwrap));
     logger.log('Wrote version %s to %s', version, shrinkwrapPath);
   }
 
   if (await pathExists(packageLockPath)) {
-    const packageLock = await readJson(packageLockPath);
-    await writeJson(packageLockPath, {...packageLock, ...{version}}, {spaces: 2});
+    const packageLock = await readFile(packageLockPath, 'utf8');
+    await writeJson(packageLockPath, {...parseJson(packageLock), ...{version}}, getWriteOptions(packageLock));
     logger.log('Wrote version %s to %s', version, packageLockPath);
   }
 };
+
+function getWriteOptions(content) {
+  return {spaces: detectIndent(content).indent || DEFAULT_INDENT, EOL: detectNewline(content) || DEFAULT_NEWLINE};
+}

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
   "dependencies": {
     "@semantic-release/error": "^2.2.0",
     "aggregate-error": "^1.0.0",
+    "detect-indent": "^5.0.0",
+    "detect-newline": "^2.1.0",
     "execa": "^0.10.0",
     "fs-extra": "^6.0.0",
     "lodash": "^4.17.4",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^2.0.1",
+    "parse-json": "^4.0.0",
     "read-pkg": "^3.0.0",
     "registry-auth-token": "^3.3.1"
   },


### PR DESCRIPTION
Fix #70

Inspired by https://github.com/npm/npm/blob/1365694bb3da9be95964a4eb6c92b1c71d0edde5/lib/install/save.js#L54 which use the same libs.