### PR TITLE
fix: don't attempt to call an undefined validator

### DIFF
--- a/lib/verify-config.js
+++ b/lib/verify-config.js
@@ -12,7 +12,7 @@ const VALIDATORS = {
 module.exports = options => {
   const errors = Object.entries(options).reduce(
     (errors, [option, value]) =>
-      !isUndefined(value) && value !== false && !VALIDATORS[option](value)
+      !isUndefined(value) && value !== false && !(VALIDATORS[option] ? VALIDATORS[option](value) : true)
         ? [...errors, getError(`EINVALID${option.toUpperCase()}`, {[option]: value})]
         : errors,
     []


### PR DESCRIPTION
I'm not sure in what situation this manifests, but my releases have been failing since this was released: https://travis-ci.org/kentcdodds/babel-plugin-preval/builds/397549428