### PR TITLE
fix: fixes incorrect escaping on legacy workflow

### DIFF
--- a/lib/set-npmrc-auth.js
+++ b/lib/set-npmrc-auth.js
@@ -6,13 +6,13 @@ const getError = require('./get-error');
 
 module.exports = async (registry, logger) => {
   logger.log('Verify authentication for registry %s', registry);
-  const {NPM_TOKEN, NPM_USERNAME, NPM_PASSWORD, NPM_EMAIL} = process.env;
+  const {NPM_TOKEN, NPM_USERNAME, NPM_PASSWORD, NPM_EMAIL, LEGACY_TOKEN} = process.env;
 
   if (getAuthToken(registry)) {
     return;
   }
   if (NPM_USERNAME && NPM_PASSWORD && NPM_EMAIL) {
-    await appendFile('./.npmrc', `\n_auth = ${Buffer.from(`\${LEGACY_TOKEN}\nemail = \${NPM_EMAIL}`)}`);
+    await appendFile('./.npmrc', `\n_auth = ${Buffer.from(`${LEGACY_TOKEN}\nemail = ${NPM_EMAIL}`)}`);
     logger.log('Wrote NPM_USERNAME, NPM_PASSWORD and NPM_EMAIL to .npmrc.');
   } else if (NPM_TOKEN) {
     await appendFile('./.npmrc', `\n${nerfDart(registry)}:_authToken = \${NPM_TOKEN}`);

--- a/test/set-npmrc-auth.test.js
+++ b/test/set-npmrc-auth.test.js
@@ -42,11 +42,12 @@ test.serial('Set auth with "NPM_USERNAME", "NPM_PASSWORD" and "NPM_EMAIL"', asyn
   process.env.NPM_USERNAME = 'npm_username';
   process.env.NPM_PASSWORD = 'npm_pasword';
   process.env.NPM_EMAIL = 'npm_email';
+  process.env.LEGACY_TOKEN = 'legacy_token';
 
   await setNpmrcAuth('http://custom.registry.com', t.context.logger);
 
   const npmrc = (await readFile('.npmrc')).toString();
-  t.is(npmrc, `\n_auth = \${LEGACY_TOKEN}\nemail = \${NPM_EMAIL}`);
+  t.is(npmrc, `\n_auth = ${process.env.LEGACY_TOKEN}\nemail = ${process.env.NPM_EMAIL}`);
   t.deepEqual(t.context.log.args[1], ['Wrote NPM_USERNAME, NPM_PASSWORD and NPM_EMAIL to .npmrc.']);
 });
 


### PR DESCRIPTION
The auth string that is written to the .npmrc file during the legacy workflow contained variable
names rather than values. Such as:

```
// .npmrc
_auth = ${LEGACY_TOKEN}
email = ${NPM_EMAIL}
```
 This commit fixes incorrect escaping to resolve this.