### PR TITLE
 feat: log npm CLI output to `stdout`/`stderr`

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -3,13 +3,17 @@ const {move} = require('fs-extra');
 const execa = require('execa');
 const updatePackageVersion = require('./update-package-version');
 
-module.exports = async ({tarballDir, pkgRoot}, {cwd, nextRelease: {version}, logger}) => {
+module.exports = async ({tarballDir, pkgRoot}, {cwd, env, stdout, stderr, nextRelease: {version}, logger}) => {
   const basePath = pkgRoot ? path.resolve(cwd, pkgRoot) : cwd;
   await updatePackageVersion(version, basePath, logger);
 
   if (tarballDir) {
     logger.log('Creating npm package version %s', version);
-    const tarball = (await execa.stdout('npm', ['pack', basePath], {cwd})).split('\n').pop();
+    const shell = execa('npm', ['pack', basePath], {cwd, env});
+    shell.stdout.pipe(stdout);
+    shell.stderr.pipe(stderr);
+
+    const tarball = (await shell).stdout.split('\n').pop();
     await move(path.resolve(cwd, tarball), path.resolve(cwd, tarballDir.trim(), tarball));
   }
 };

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -7,6 +7,8 @@ module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
   const {
     cwd,
     env,
+    stdout,
+    stderr,
     nextRelease: {version},
     logger,
   } = context;
@@ -16,7 +18,10 @@ module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
     const registry = getRegistry(pkg, context);
 
     logger.log('Publishing version %s to npm registry', version);
-    await execa('npm', ['publish', basePath, '--registry', registry], {cwd, env});
+    const shell = execa('npm', ['publish', basePath, '--registry', registry], {cwd, env});
+    shell.stdout.pipe(stdout);
+    shell.stderr.pipe(stderr);
+    await shell;
 
     logger.log(`Published ${pkg.name}@${pkg.version} on ${registry}`);
     return getReleaseInfo(pkg, context, registry);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash": "^4.17.4",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^3.0.0",
+    "npm": "^6.3.0",
     "parse-json": "^4.0.0",
     "rc": "^1.2.8",
     "read-pkg": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "p-retry": "^2.0.0",
     "semantic-release": "^15.0.0",
     "sinon": "^6.0.0",
+    "stream-buffers": "^3.0.2",
     "tempy": "^0.2.1",
     "xo": "^0.21.0"
   },
@@ -80,7 +81,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=15.8.0 <16.0.0"
+    "semantic-release": ">=15.9.0 <16.0.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
feat: add dependency to `npm`

The plugin will now use the npm version in its dependencies to run npm commands.
That allow to avoid bugs in outdated npm version. And Greenkeeper will automatically test the plugin for new npm releases.

feat: log npm CLI output to `stdout`/`stderr`

Will help to debug what's npm is doing when the plugin calls `npm pack` and `npm publish`, in particular regarding `prepack` and `prepublish` functions