### PR TITLE
fix: always attempt to set the legacy token env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,13 @@ async function verifyConditions(pluginConfig, context) {
 
   const errors = verifyNpmConfig(pluginConfig);
 
+  setLegacyToken(context);
+
   try {
     const pkg = await getPkg(pluginConfig, context);
 
     // Verify the npm authentication only if `npmPublish` is not false and `pkg.private` is not `true`
     if (pluginConfig.npmPublish !== false && pkg.private !== true) {
-      setLegacyToken(context);
       await verifyNpmAuth(pluginConfig, pkg, context);
     }
   } catch (error) {
@@ -44,11 +45,12 @@ async function prepare(pluginConfig, context) {
   let pkg;
   const errors = verified ? [] : verifyNpmConfig(pluginConfig);
 
+  setLegacyToken(context);
+
   try {
     // Reload package.json in case a previous external step updated it
     pkg = await getPkg(pluginConfig, context);
     if (!verified && pluginConfig.npmPublish !== false && pkg.private !== true) {
-      setLegacyToken(context);
       await verifyNpmAuth(pluginConfig, pkg, context);
     }
   } catch (error) {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -65,6 +65,7 @@ test('Skip npm auth verification if "package.private" is true', async t => {
       {npmPublish: false},
       {
         cwd,
+        env: {},
         options: {publish: ['@semantic-release/npm']},
         stdout: t.context.stdout,
         stderr: t.context.stderr,
@@ -83,6 +84,7 @@ test('Skip npm token verification if "package.private" is true', async t => {
       {},
       {
         cwd,
+        env: {},
         options: {publish: ['@semantic-release/npm']},
         stdout: t.context.stdout,
         stderr: t.context.stderr,


### PR DESCRIPTION
Any npm command, include `npm version` attempts to exapand the `LEGACY_TOKEN` environment varialbe if it is set in `.npmrc`.