### PR TITLE
fix for recent change of NPM publishing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,12 @@ Use either `NPM_TOKEN` for token authentication or `NPM_USERNAME`, `NPM_PASSWORD
 |--------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | `npmPublish` | Whether to publish the `npm` package to the registry. If `false` the `package.json` version will still be updated.  | `false` if the `package.json` [private](https://docs.npmjs.com/files/package.json#private) property is `true`, `true` otherwise. |
 | `pkgRoot`    | Directory path to publish.                                                                                          | `.`                                                                                                                              |
-| `tarballDir` | Directory path in which to write the the package tarball. If `false` the tarball is not be kept on the file system. | `false`                                                                                                                          |
+| `tarballDir` | Directory path in which to write the the package tarball. If `false` the tarball is not be kept on the file system. | `false`                                                                                                                             |
+| `access`     | Tells the registry whether this package should be published as `public` or `restricted`.                            | `'restricted'`                                                                                                                             |
 
 **Note**: The `pkgRoot` directory must contains a `package.json`. The version will be updated only in the `package.json` and `npm-shrinkwrap.json` within the `pkgRoot` directory.
+
+**Note**: The `access` must be set to `public` if you don’t have a paid account and trying to push to the official registry, see [npm documentation](https://docs.npmjs.com/cli/publish#description).
 
 **Note**: If you use a [shareable configuration](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/shareable-configurations.md#shareable-configurations) that defines one of these options you can set it to `false` in your [**semantic-release** configuration](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#configuration) in order to use the default value.
 
@@ -84,6 +87,21 @@ The [`registry`](https://docs.npmjs.com/misc/registry) and [`dist-tag`](https://
 
 ### Examples
 
+The `access` value `public` must be set up if you publish a public package to npmjs.com:
+
+```json
+{
+  "plugins": [
+    ["@semantic-release/npm", {
+      "access": "public"
+    }],
+    ["@semantic-release/github", {
+      "assets": "dist/*.tgz"
+    }]
+  ]
+}
+```
+
 The `npmPublish` and `tarballDir` option can be used to skip the publishing to the `npm` registry and instead, release the package tarball with another plugin. For example with the [@semantic-release/github](https://github.com/semantic-release/github) plugin:
 
 ```json
@@ -93,7 +111,7 @@ The `npmPublish` and `tarballDir` option can be used to skip the publishing to t
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", {
       "npmPublish": false,
-      "tarballDir": "dist",
+      "tarballDir": "dist"
     }],
     ["@semantic-release/github", {
       "assets": "dist/*.tgz"

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const getRegistry = require('./get-registry');
 const getReleaseInfo = require('./get-release-info');
 
-module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
+module.exports = async ({npmPublish, pkgRoot, access = 'restricted'}, pkg, context) => {
   const {
     cwd,
     env,
@@ -18,7 +18,7 @@ module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
     const registry = getRegistry(pkg, context);
 
     logger.log('Publishing version %s to npm registry', version);
-    const result = execa('npm', ['publish', basePath, '--registry', registry], {
+    const result = execa('npm', ['publish', basePath, '--registry', registry, '--access', access], {
       cwd,
       env,
     });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -242,7 +242,7 @@ test('Publish the package', async t => {
   await outputJson(path.resolve(cwd, 'package.json'), pkg);
 
   const result = await t.context.m.publish(
-    {},
+    {access: 'public'},
     {
       cwd,
       env,
@@ -267,7 +267,7 @@ test('Publish the package on a dist-tag', async t => {
   await outputJson(path.resolve(cwd, 'package.json'), pkg);
 
   const result = await t.context.m.publish(
-    {},
+    {access: 'public'},
     {
       cwd,
       env,
@@ -292,7 +292,7 @@ test('Publish the package from a sub-directory', async t => {
   await outputJson(path.resolve(cwd, 'dist/package.json'), pkg);
 
   const result = await t.context.m.publish(
-    {pkgRoot: 'dist'},
+    {pkgRoot: 'dist', access: 'public'},
     {
       cwd,
       env,
@@ -557,7 +557,7 @@ test('Verify token and set up auth only on the fist call, then prepare on prepar
   );
 
   const result = await t.context.m.publish(
-    {},
+    {access: 'public'},
     {
       cwd,
       env,


### PR DESCRIPTION
Since a couple of days NPM broke the normal publishing process.

![image](https://user-images.githubusercontent.com/13453858/48959068-48fad900-ef63-11e8-8635-d747cf5a7340.png)

The problem and solution are present here:

https://stackoverflow.com/questions/53420758/npm-publish-gives-unscoped-packages-cannot-be-private

In fact, the change is that now in order to push the public package one must set the access parameter to public:

```
npm publish --access public
```

This PR aims to keep the original NPM behavior and sets the default value to 'restricted', however there must be a way to set it to public when one needs it (say every OSS project will suffer otherwise)

Please review ASAP.
