### PR TITLE
fix: return `false` if the npm publish is skipped

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -32,8 +32,11 @@ module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
     logger.log(`Published ${pkg.name}@${pkg.version} on ${registry}`);
     return getReleaseInfo(pkg, context, registry);
   }
+
   logger.log(
     'Skip publishing to npm registry as %s is %s',
     ...(npmPublish === false ? ['npmPublish', false] : ["package.json's private property", true])
   );
+
+  return false;
 };

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,10 +18,7 @@ module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
     const registry = getRegistry(pkg, context);
 
     logger.log('Publishing version %s to npm registry', version);
-    const result = execa('npm', ['publish', basePath, '--registry', registry], {
-      cwd,
-      env,
-    });
+    const result = execa('npm', ['publish', basePath, '--registry', registry], {cwd, env});
     result.stdout.pipe(
       stdout,
       {end: false}

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -329,7 +329,7 @@ test('Create the package and skip publish ("npmPublish" is false)', async t => {
     }
   );
 
-  t.falsy(result);
+  t.false(result);
   t.is((await readJson(path.resolve(cwd, 'package.json'))).version, '1.0.0');
   t.true(await pathExists(path.resolve(cwd, `tarball/${pkg.name}-1.0.0.tgz`)));
   await t.throws(execa('npm', ['view', pkg.name, 'version'], {cwd, env: testEnv}));
@@ -354,7 +354,7 @@ test('Create the package and skip publish ("package.private" is true)', async t 
     }
   );
 
-  t.falsy(result);
+  t.false(result);
   t.is((await readJson(path.resolve(cwd, 'package.json'))).version, '1.0.0');
   t.true(await pathExists(path.resolve(cwd, `tarball/${pkg.name}-1.0.0.tgz`)));
   await t.throws(execa('npm', ['view', pkg.name, 'version'], {cwd, env: testEnv}));
@@ -379,7 +379,7 @@ test('Create the package and skip publish from a sub-directory ("npmPublish" is 
     }
   );
 
-  t.falsy(result);
+  t.false(result);
   t.is((await readJson(path.resolve(cwd, 'dist/package.json'))).version, '1.0.0');
   t.true(await pathExists(path.resolve(cwd, `tarball/${pkg.name}-1.0.0.tgz`)));
   await t.throws(execa('npm', ['view', pkg.name, 'version'], {cwd, env: testEnv}));
@@ -409,7 +409,7 @@ test('Create the package and skip publish from a sub-directory ("package.private
     }
   );
 
-  t.falsy(result);
+  t.false(result);
   t.is((await readJson(path.resolve(cwd, 'dist/package.json'))).version, '1.0.0');
   t.true(await pathExists(path.resolve(cwd, `tarball/${pkg.name}-1.0.0.tgz`)));
   await t.throws(execa('npm', ['view', pkg.name, 'version'], {cwd, env: testEnv}));


### PR DESCRIPTION
Fix semantic-release/github#139