### PR TITLE
update npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.4",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^4.0.0",
-    "npm": "^6.8.0",
+    "npm": "^6.9.0",
     "rc": "^1.2.8",
     "read-pkg": "^5.0.0",
     "registry-auth-token": "^3.3.1"


### PR DESCRIPTION
this will solve two warnings during yarn install:
`
warning @semantic-release/npm > npm > npm-registry-fetch@1.1.1: this version has a breaking change. use 1.1.0 or upgrade to latest
warning @semantic-release/npm > npm > npm-registry-fetch > make-fetch-happen > socks-proxy-agent > socks@1.1.10: If using 2.x branch, please upgrade to at least 2.1.6 to avoid a serious bug with socket data flow and an import issue introduced in 2.1.0
`