### PR TITLE
registry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ Publish to [GitHub’s npm registry](https://help.github.com/en/articles/configu
 }
 ```
 
+Publish to multiple registries
+
+```json
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/npm",
+      {
+        "registry": ["https://npm.pkg.github.com/", "https://registry.npmjs.org/"]
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}
+```
+
 When publishing from a sub-directory with the `pkgRoot` option, the `package.json` and `npm-shrinkwrap.json` updated with the new version can be moved to another directory with a `postpublish` [npm script](https://docs.npmjs.com/misc/scripts). For example with the [@semantic-release/git](https://github.com/semantic-release/git) plugin:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/npm/next.svg)](https://www.npmjs.com/package/@semantic-release/npm)
 
 | Step               | Description                                                                                                                                   |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `verifyConditions` | Verify the presence of the `NPM_TOKEN` environment variable, create or update the `.npmrc` file with the token and verify the token is valid. |
 | `prepare`          | Update the `package.json` version and [create](https://docs.npmjs.com/cli/pack) the npm package tarball.                                      |
 | `publish`          | [Publish the npm package](https://docs.npmjs.com/cli/publish) to the registry.                                                                |
@@ -27,11 +27,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 
 ```json
 {
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
-  ]
+  "plugins": ["@semantic-release/commit-analyzer", "@semantic-release/release-notes-generator", "@semantic-release/npm"]
 }
 ```
 
@@ -59,9 +55,10 @@ Use either `NPM_TOKEN` for token authentication or `NPM_USERNAME`, `NPM_PASSWORD
 ### Options
 
 | Options      | Description                                                                                                         | Default                                                                                                                          |
-|--------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| ------------ | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `npmPublish` | Whether to publish the `npm` package to the registry. If `false` the `package.json` version will still be updated.  | `false` if the `package.json` [private](https://docs.npmjs.com/files/package.json#private) property is `true`, `true` otherwise. |
 | `pkgRoot`    | Directory path to publish.                                                                                          | `.`                                                                                                                              |
+| `registry`   | Registry to publish to.                                                                                             | `https://registry.npmjs.org/`                                                                                                    |
 | `tarballDir` | Directory path in which to write the the package tarball. If `false` the tarball is not be kept on the file system. | `false`                                                                                                                          |
 
 **Note**: The `pkgRoot` directory must contains a `package.json`. The version will be updated only in the `package.json` and `npm-shrinkwrap.json` within the `pkgRoot` directory.
@@ -73,6 +70,7 @@ Use either `NPM_TOKEN` for token authentication or `NPM_USERNAME`, `NPM_PASSWORD
 The plugin uses the [`npm` CLI](https://github.com/npm/cli) which will read the configuration from [`.npmrc`](https://docs.npmjs.com/files/npmrc). See [`npm config`](https://docs.npmjs.com/misc/config) for the option list.
 
 The [`registry`](https://docs.npmjs.com/misc/registry) and [`dist-tag`](https://docs.npmjs.com/cli/dist-tag) can be configured in the `package.json` and will take precedence over the configuration in `.npmrc`:
+
 ```json
 {
   "publishConfig": {
@@ -91,13 +89,37 @@ The `npmPublish` and `tarballDir` option can be used to skip the publishing to t
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/npm", {
-      "npmPublish": false,
-      "tarballDir": "dist",
-    }],
-    ["@semantic-release/github", {
-      "assets": "dist/*.tgz"
-    }]
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false,
+        "tarballDir": "dist"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": "dist/*.tgz"
+      }
+    ]
+  ]
+}
+```
+
+Publish to [GitHub’s npm registry](https://help.github.com/en/articles/configuring-npm-for-use-with-github-package-registry).
+
+```json
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/npm",
+      {
+        "registry": "https://npm.pkg.github.com/"
+      }
+    ],
+    "@semantic-release/github"
   ]
 }
 ```
@@ -109,15 +131,22 @@ When publishing from a sub-directory with the `pkgRoot` option, the `package.jso
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/npm", {
-      "pkgRoot": "dist",
-    }],
-    ["@semantic-release/git", {
-      "assets": ["package.json", "npm-shrinkwrap.json"]
-    }]
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "dist"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "npm-shrinkwrap.json"]
+      }
+    ]
   ]
 }
 ```
+
 ```json
 {
   "scripts": {

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ async function verifyConditions(pluginConfig, context) {
     pluginConfig.npmPublish = defaultTo(pluginConfig.npmPublish, publishPlugin.npmPublish);
     pluginConfig.tarballDir = defaultTo(pluginConfig.tarballDir, publishPlugin.tarballDir);
     pluginConfig.pkgRoot = defaultTo(pluginConfig.pkgRoot, publishPlugin.pkgRoot);
+    pluginConfig.registry = defaultTo(pluginConfig.registry, publishPlugin.registry);
   }
 
   const errors = verifyNpmConfig(pluginConfig);

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -22,6 +22,12 @@ Your configuration for the \`tarballDir\` option is \`${tarballDir}\`.`,
 
 Your configuration for the \`pkgRoot\` option is \`${pkgRoot}\`.`,
   }),
+  EINVALIDREGISTRY: ({registry}) => ({
+    message: 'Invalid `registry` option.',
+    details: `The [registry option](${linkify('README.md#registry')}) option, if defined, must be a \`String\`.
+
+Your configuration for the \`registry\` option is \`${registry}\`.`,
+  }),
   ENONPMTOKEN: ({registry}) => ({
     message: 'No npm token specified.',
     details: `An [npm token](${linkify(

--- a/lib/get-registry.js
+++ b/lib/get-registry.js
@@ -2,10 +2,17 @@ const path = require('path');
 const rc = require('rc');
 const getRegistryUrl = require('registry-auth-token/registry-url');
 
-module.exports = ({publishConfig: {registry} = {}, name}, {cwd}) =>
-  registry
-    ? registry
-    : getRegistryUrl(
-        name.split('/')[0],
-        rc('npm', {registry: 'https://registry.npmjs.org/'}, {config: path.resolve(cwd, '.npmrc')})
-      );
+module.exports = (pluginConfig, {publishConfig: {registry} = {}, name}, {cwd}) => {
+  if (pluginConfig.registry) {
+    return pluginConfig.registry;
+  }
+
+  if (registry) {
+    return registry;
+  }
+
+  return getRegistryUrl(
+    name.split('/')[0],
+    rc('npm', {registry: 'https://registry.npmjs.org/'}, {config: path.resolve(cwd, '.npmrc')})
+  );
+};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const getRegistry = require('./get-registry');
 const getReleaseInfo = require('./get-release-info');
 
-module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
+module.exports = async ({npmPublish, pkgRoot, registry: registryOption}, pkg, context) => {
   const {
     cwd,
     env,
@@ -15,7 +15,7 @@ module.exports = async ({npmPublish, pkgRoot}, pkg, context) => {
 
   if (npmPublish !== false && pkg.private !== true) {
     const basePath = pkgRoot ? path.resolve(cwd, pkgRoot) : cwd;
-    const registry = getRegistry(pkg, context);
+    const registry = getRegistry({registry: registryOption}, pkg, context);
 
     logger.log('Publishing version %s to npm registry', version);
     const result = execa('npm', ['publish', basePath, '--registry', registry], {cwd, env});

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -10,7 +10,7 @@ module.exports = async (pluginConfig, pkg, context) => {
     cwd,
     env: {DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/', ...env},
   } = context;
-  const registry = getRegistry(pkg, context);
+  const registry = getRegistry(pluginConfig, pkg, context);
 
   await setNpmrcAuth(registry, context);
 

--- a/lib/verify-config.js
+++ b/lib/verify-config.js
@@ -7,10 +7,11 @@ const VALIDATORS = {
   npmPublish: isBoolean,
   tarballDir: isNonEmptyString,
   pkgRoot: isNonEmptyString,
+  registry: isNonEmptyString,
 };
 
-module.exports = ({npmPublish, tarballDir, pkgRoot}) => {
-  const errors = Object.entries({npmPublish, tarballDir, pkgRoot}).reduce(
+module.exports = ({npmPublish, tarballDir, pkgRoot, registry}) => {
+  const errors = Object.entries({npmPublish, tarballDir, pkgRoot, registry}).reduce(
     (errors, [option, value]) =>
       !isNil(value) && !VALIDATORS[option](value)
         ? [...errors, getError(`EINVALID${option.toUpperCase()}`, {[option]: value})]

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "trailingComma": "es5"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "next"
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/test/get-registry.test.js
+++ b/test/get-registry.test.js
@@ -6,15 +6,15 @@ import getRegistry from '../lib/get-registry';
 
 test('Get default registry', t => {
   const cwd = tempy.directory();
-  t.is(getRegistry({name: 'package-name'}, {cwd}), 'https://registry.npmjs.org/');
-  t.is(getRegistry({name: 'package-name', publishConfig: {}}, {cwd}), 'https://registry.npmjs.org/');
+  t.is(getRegistry({}, {name: 'package-name'}, {cwd}), 'https://registry.npmjs.org/');
+  t.is(getRegistry({}, {name: 'package-name', publishConfig: {}}, {cwd}), 'https://registry.npmjs.org/');
 });
 
 test('Get the registry configured in ".npmrc" and normalize trailing slash', async t => {
   const cwd = tempy.directory();
   await appendFile(path.resolve(cwd, '.npmrc'), 'registry = https://custom1.registry.com');
 
-  t.is(getRegistry({name: 'package-name'}, {cwd}), 'https://custom1.registry.com/');
+  t.is(getRegistry({}, {name: 'package-name'}, {cwd}), 'https://custom1.registry.com/');
 });
 
 test('Get the registry configured from "publishConfig"', async t => {
@@ -22,7 +22,7 @@ test('Get the registry configured from "publishConfig"', async t => {
   await appendFile(path.resolve(cwd, '.npmrc'), 'registry = https://custom2.registry.com');
 
   t.is(
-    getRegistry({name: 'package-name', publishConfig: {registry: 'https://custom3.registry.com/'}}, {cwd}),
+    getRegistry({}, {name: 'package-name', publishConfig: {registry: 'https://custom3.registry.com/'}}, {cwd}),
     'https://custom3.registry.com/'
   );
 });
@@ -31,5 +31,9 @@ test('Get the registry configured in ".npmrc" for scoped package', async t => {
   const cwd = tempy.directory();
   await appendFile(path.resolve(cwd, '.npmrc'), '@scope:registry = https://custom3.registry.com');
 
-  t.is(getRegistry({name: '@scope/package-name'}, {cwd}), 'https://custom3.registry.com/');
+  t.is(getRegistry({}, {name: '@scope/package-name'}, {cwd}), 'https://custom3.registry.com/');
+});
+
+test('Get the registry configured from plugin options', t => {
+  t.is(getRegistry({registry: 'https://custom3.registry.com/'}, {}, {}), 'https://custom3.registry.com/');
 });

--- a/test/verify-config.test.js
+++ b/test/verify-config.test.js
@@ -36,11 +36,24 @@ test('Return SemanticReleaseError if "pkgRoot" option is not a String', async t 
   t.is(error.code, 'EINVALIDPKGROOT');
 });
 
+test('Return SemanticReleaseError if "registry" option is not a String', async t => {
+  const registry = 42;
+  const [error] = await verify({registry}, {}, t.context.logger);
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDREGISTRY');
+});
+
 test('Return SemanticReleaseError Array if multiple config are invalid', async t => {
   const npmPublish = 42;
   const tarballDir = 42;
   const pkgRoot = 42;
-  const [error1, error2, error3] = await verify({npmPublish, tarballDir, pkgRoot}, {}, t.context.logger);
+  const registry = 42;
+  const [error1, error2, error3, error4] = await verify(
+    {npmPublish, tarballDir, pkgRoot, registry},
+    {},
+    t.context.logger
+  );
 
   t.is(error1.name, 'SemanticReleaseError');
   t.is(error1.code, 'EINVALIDNPMPUBLISH');
@@ -50,4 +63,7 @@ test('Return SemanticReleaseError Array if multiple config are invalid', async t
 
   t.is(error3.name, 'SemanticReleaseError');
   t.is(error3.code, 'EINVALIDPKGROOT');
+
+  t.is(error4.name, 'SemanticReleaseError');
+  t.is(error4.code, 'EINVALIDREGISTRY');
 });


### PR DESCRIPTION
closes #147

I’ve published a fork for testing `npm install -D @gr2m/semantic-release-npm-161`, then configure the fork to be used

```json
  "semantic-release": {
    "plugins": [
      "@semantic-release/commit-analyzer",
      "@semantic-release/release-notes-generator",
      [
        "@gr2m/semantic-release-npm-161",
        {
          "registry": "https://npm.pkg.github.com/"
        }
      ],
      "@semantic-release/github"
    ]
  },
```