### PR TITLE
Honor NPM_CONFIG_USERCONFIG setting

### DIFF
--- a/lib/set-npmrc-auth.js
+++ b/lib/set-npmrc-auth.js
@@ -6,9 +6,12 @@ const nerfDart = require('nerf-dart');
 const AggregateError = require('aggregate-error');
 const getError = require('./get-error');
 
-module.exports = async (registry, {cwd, env: {NPM_TOKEN, NPM_USERNAME, NPM_PASSWORD, NPM_EMAIL}, logger}) => {
+module.exports = async (
+  registry,
+  {cwd, env: {NPM_TOKEN, NPM_CONFIG_USERCONFIG, NPM_USERNAME, NPM_PASSWORD, NPM_EMAIL}, logger}
+) => {
   logger.log('Verify authentication for registry %s', registry);
-  const config = path.resolve(cwd, '.npmrc');
+  const config = NPM_CONFIG_USERCONFIG || path.resolve(cwd, '.npmrc');
   if (getAuthToken(registry, {npmrc: rc('npm', {registry: 'https://registry.npmjs.org/'}, {config})})) {
     return;
   }

--- a/test/set-npmrc-auth.test.js
+++ b/test/set-npmrc-auth.test.js
@@ -70,6 +70,20 @@ test('Throw error if "NPM_TOKEN" is missing', async t => {
   t.is(error.code, 'ENONPMTOKEN');
 });
 
+test('Emulate npm config resolution if "NPM_CONFIG_USERCONFIG" is set', async t => {
+  const cwd = tempy.directory();
+
+  await appendFile(path.resolve(cwd, '.custom-npmrc'), `//custom.registry.com/:_authToken = \${NPM_TOKEN}`);
+
+  await setNpmrcAuth('http://custom.registry.com', {
+    cwd,
+    env: {NPM_CONFIG_USERCONFIG: path.resolve(cwd, '.custom-npmrc')},
+    logger: t.context.logger,
+  });
+
+  t.is(t.context.log.callCount, 1);
+});
+
 test('Throw error if "NPM_USERNAME" is missing', async t => {
   const cwd = tempy.directory();
   const env = {NPM_PASSWORD: 'npm_pasword', NPM_EMAIL: 'npm_email'};


### PR DESCRIPTION
This bug cost me weeks 😅

`npm` honors the `NPM_CONFIG_USERCONFIG` setting, which our CI relies on to inject shared credentials at runtime. `npm publish` succeeds if we're not using Semantic Release. However, `@semantic-release/npm` has reimplemented a credentials check in a manner not compatible with the way `npm` handles the user config environment variable. This PR checks the location specified in `NPM_CONFIG_USERCONFIG` before using `rc` to crawl up the file hierarchy.

It should be noted that `rc` does not fully implement the `.npmrc` resolution algorithm, skipping the ability to specify config files from an env var. That's why we're facing this problem.

I've tested this locally, and this small fix would allow us to use Semantic Release 🎉