### PR TITLE
fix: revert to execa `^1.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@semantic-release/error": "^2.2.0",
     "aggregate-error": "^3.0.0",
-    "execa": "^2.0.0",
+    "execa": "^1.0.0",
     "fs-extra": "^8.0.0",
     "lodash": "^4.17.4",
     "nerf-dart": "^1.0.0",


### PR DESCRIPTION
closes #172