### PR TITLE
fix: use correct peerDependencies for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=15.9.0 <17.0.0"
+    "semantic-release": ">=16.0.0-beta <17.0.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
`semantic-release@v16-beta` isn't satisfied for current `peerDependency` range:

```
##[error]npm WARN @semantic-release/npm@6.0.0-beta.3 requires a peer of semantic-release@>=15.9.0 <17.0.0 but none is installed.
```