### PR TITLE
docs(README): fix columns of options table in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/npm/next.svg)](https://www.npmjs.com/package/@semantic-release/npm)
 [![npm beta version](https://img.shields.io/npm/v/@semantic-release/npm/beta.svg)](https://www.npmjs.com/package/@semantic-release/npm)
 
-| Step               | Description                                                                                                                                   |                                                                     |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-| `verifyConditions` | Verify the presence of the `NPM_TOKEN` environment variable, create or update the `.npmrc` file with the token and verify the token is valid. |                                                                     |
-| `prepare`          | Update the `package.json` version and [create](https://docs.npmjs.com/cli/pack) the npm package tarball.                                      |                                                                     |
-| `addChannel`       |                                                                                                                                               | [Add a release to a dist-tag](https://docs.npmjs.com/cli/dist-tag). |
-| `publish`          | [Publish the npm package](https://docs.npmjs.com/cli/publish) to the registry.                                                                |                                                                     |
+| Step               | Description |
+|--------------------|-------------|
+| `verifyConditions` | Verify the presence of the `NPM_TOKEN` environment variable, create or update the `.npmrc` file with the token and verify the token is valid. |
+| `prepare`          | Update the `package.json` version and [create](https://docs.npmjs.com/cli/pack) the npm package tarball. |
+| `addChannel`       | [Add a release to a dist-tag](https://docs.npmjs.com/cli/dist-tag). |
+| `publish`          | [Publish the npm package](https://docs.npmjs.com/cli/publish) to the registry. |
 
 ## Install
 


### PR DESCRIPTION
### What's changed?

In the options table, the columns weren't matching so I've updated the markdown so there are only 2 columns. Was this intended or auto-formatted this way?