### PR TITLE
Updating node and npm version in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.17.15",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^5.0.0",
-    "npm": "^6.10.3",
+    "npm": "^6.13.0",
     "rc": "^1.2.8",
     "read-pkg": "^5.0.0",
     "registry-auth-token": "^4.0.0",
@@ -47,7 +47,7 @@
     "xo": "^0.29.0"
   },
   "engines": {
-    "node": ">=10.18"
+    "node": ">=10.19"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Hi, I made this PR to update the node version since when I tried the lowest version in the package, it throws an error for got dependency
```sh
error got@11.6.0: The engine "node" is incompatible with this module. Expected version ">=10.19.0". Got "10.18.1"
error Found incompatible module.
```
I also update npm dependency because the actual version has a subdependency in its treeDependency that give me a vulnerability issue detected from github.
Hope this could help.