### PR TITLE
Upgrade npm and xo dependencies

### DIFF
--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -22,7 +22,7 @@ module.exports = async (npmrc, pkg, context) => {
       whoamiResult.stdout.pipe(stdout, {end: false});
       whoamiResult.stderr.pipe(stderr, {end: false});
       await whoamiResult;
-    } catch (_) {
+    } catch {
       throw new AggregateError([getError('EINVALIDNPMTOKEN', {registry})]);
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.17.15",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^5.0.0",
-    "npm": "^6.13.0",
+    "npm": "^6.14.8",
     "rc": "^1.2.8",
     "read-pkg": "^5.0.0",
     "registry-auth-token": "^4.0.0",
@@ -44,7 +44,7 @@
     "semantic-release": "^17.0.0",
     "sinon": "^9.0.0",
     "stream-buffers": "^3.0.2",
-    "xo": "^0.29.0"
+    "xo": "^0.33.1"
   },
   "engines": {
     "node": ">=10.19"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "got": "^11.0.0",
     "nyc": "^15.0.0",
     "p-retry": "^4.0.0",
+    "prettier": "^2.1.2",
     "semantic-release": "^17.0.0",
     "sinon": "^9.0.0",
     "stream-buffers": "^3.0.2",
@@ -100,7 +101,8 @@
     "prettier": true,
     "space": true,
     "rules": {
-      "unicorn/string-content": "off"
+      "unicorn/string-content": "off",
+      "unicorn/no-reduce": "off"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "got": "^11.0.0",
     "nyc": "^15.0.0",
     "p-retry": "^4.0.0",
-    "prettier": "^2.1.2",
     "semantic-release": "^17.0.0",
     "sinon": "^9.0.0",
     "stream-buffers": "^3.0.2",

--- a/test/helpers/npm-registry.js
+++ b/test/helpers/npm-registry.js
@@ -39,7 +39,7 @@ async function start() {
       minTimeout: 1000,
       factor: 2,
     });
-  } catch (_) {
+  } catch {
     throw new Error(`Couldn't start npm-docker-couchdb after 2 min`);
   }
 


### PR DESCRIPTION
npm upgrade is just to have the latest version. On the other hand, after npm install and npm audit, xo appears as a low vulnerability, so it recommends the actual version that it's set in this PR.