### PR TITLE
Allow use of npm automation tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ async function verifyConditions(pluginConfig, context) {
     pluginConfig.npmPublish = defaultTo(pluginConfig.npmPublish, publishPlugin.npmPublish);
     pluginConfig.tarballDir = defaultTo(pluginConfig.tarballDir, publishPlugin.tarballDir);
     pluginConfig.pkgRoot = defaultTo(pluginConfig.pkgRoot, publishPlugin.pkgRoot);
+    pluginConfig.usesAutomationToken = defaultTo(pluginConfig.usesAutomationToken, publishPlugin.usesAutomationToken);
   }
 
   const errors = verifyNpmConfig(pluginConfig);
@@ -33,7 +34,7 @@ async function verifyConditions(pluginConfig, context) {
 
     // Verify the npm authentication only if `npmPublish` is not false and `pkg.private` is not `true`
     if (pluginConfig.npmPublish !== false && pkg.private !== true) {
-      await verifyNpmAuth(npmrc, pkg, context);
+      await verifyNpmAuth(npmrc, pkg, context, pluginConfig.usesAutomationToken);
     }
   } catch (error) {
     errors.push(...error);
@@ -55,7 +56,7 @@ async function prepare(pluginConfig, context) {
     // Reload package.json in case a previous external step updated it
     const pkg = await getPkg(pluginConfig, context);
     if (!verified && pluginConfig.npmPublish !== false && pkg.private !== true) {
-      await verifyNpmAuth(npmrc, pkg, context);
+      await verifyNpmAuth(npmrc, pkg, context, pluginConfig.usesAutomationToken);
     }
   } catch (error) {
     errors.push(...error);
@@ -79,7 +80,7 @@ async function publish(pluginConfig, context) {
     // Reload package.json in case a previous external step updated it
     pkg = await getPkg(pluginConfig, context);
     if (!verified && pluginConfig.npmPublish !== false && pkg.private !== true) {
-      await verifyNpmAuth(npmrc, pkg, context);
+      await verifyNpmAuth(npmrc, pkg, context, pluginConfig.usesAutomationToken);
     }
   } catch (error) {
     errors.push(...error);
@@ -106,7 +107,7 @@ async function addChannel(pluginConfig, context) {
     // Reload package.json in case a previous external step updated it
     pkg = await getPkg(pluginConfig, context);
     if (!verified && pluginConfig.npmPublish !== false && pkg.private !== true) {
-      await verifyNpmAuth(npmrc, pkg, context);
+      await verifyNpmAuth(npmrc, pkg, context, pluginConfig.usesAutomationToken);
     }
   } catch (error) {
     errors.push(...error);

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -5,7 +5,7 @@ const getError = require('./get-error');
 const getRegistry = require('./get-registry');
 const setNpmrcAuth = require('./set-npmrc-auth');
 
-module.exports = async (npmrc, pkg, context) => {
+module.exports = async (npmrc, pkg, context, usesAutomationToken) => {
   const {
     cwd,
     env: {DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/', ...env},
@@ -15,6 +15,10 @@ module.exports = async (npmrc, pkg, context) => {
   const registry = getRegistry(pkg, context);
 
   await setNpmrcAuth(npmrc, registry, context);
+
+  if (usesAutomationToken) {
+    return;
+  }
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {

--- a/lib/verify-config.js
+++ b/lib/verify-config.js
@@ -7,10 +7,11 @@ const VALIDATORS = {
   npmPublish: isBoolean,
   tarballDir: isNonEmptyString,
   pkgRoot: isNonEmptyString,
+  usesAutomationToken: isBoolean,
 };
 
-module.exports = ({npmPublish, tarballDir, pkgRoot}) => {
-  const errors = Object.entries({npmPublish, tarballDir, pkgRoot}).reduce(
+module.exports = ({npmPublish, tarballDir, pkgRoot, usesAutomationToken}) => {
+  const errors = Object.entries({npmPublish, tarballDir, pkgRoot, usesAutomationToken}).reduce(
     (errors, [option, value]) =>
       !isNil(value) && !VALIDATORS[option](value)
         ? [...errors, getError(`EINVALID${option.toUpperCase()}`, {[option]: value})]


### PR DESCRIPTION
Finally decided to give semantic-release a try, especially since npm recently added support for automation tokens (so I can still have 2FA enabled).

Stumbled upon a challenge when trying to use those shiny new tokens tho, and noticed a hint in https://github.com/semantic-release/npm/issues/277#issuecomment-705784318 about adding a new config option to avoid the npm whoami check when automation tokens are used.

Hence this PR; the introduction of `.usesAutomationToken` config option.

I got my very first automated release made with this in place (+ some other hacks to make the `semantic-release` package use my fork), which obviously felt awesome 🎉 

Any thoughts?

Refs https://github.com/semantic-release/npm/issues/277