### PR TITLE
docs: Fix postpublish script when "pkgRoot":"dist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ When publishing from a sub-directory with the `pkgRoot` option, the `package.jso
 ```json
 {
   "scripts": {
-    "postpublish": "cp -r dist/package.json . && cp -r dist/npm-shrinkwrap.json ."
+    "postpublish": "cp -r package.json .. && cp -r npm-shrinkwrap.json .."
   }
 }
 ```


### PR DESCRIPTION
When "pkgRoot" is set the postpublish script will excute relativly to the pkgRoot. Hence cp dist/ will generate the error "No such file or directory"