### PR TITLE
fix(deps): updating npm dependency for CWE-400

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.17.15",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^5.0.0",
-    "npm": "^6.14.8",
+    "npm": "^6.14.9",
     "rc": "^1.2.8",
     "read-pkg": "^5.0.0",
     "registry-auth-token": "^4.0.0",


### PR DESCRIPTION
The previous patch version of NPM was vulnerable by CWE-400, so I am just updating it to the latest patch version that resolved the security issue.