### PR TITLE
fix: use `NPM_CONFIG_USERCONFIG` in get-registry to match auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ Both the [token](https://docs.npmjs.com/getting-started/working_with_tokens) and
 
 ### Environment variables
 
-| Variable       | Description                                                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `NPM_TOKEN`    | Npm token created via [npm token create](https://docs.npmjs.com/getting-started/working_with_tokens#how-to-create-new-tokens) |
-| `NPM_USERNAME` | Npm username created via [npm adduser](https://docs.npmjs.com/cli/adduser) or on [npmjs.com](https://www.npmjs.com)           |
-| `NPM_PASSWORD` | Password of the npm user.                                                                                                     |
-| `NPM_EMAIL`    | Email address associated with the npm user                                                                                    |
+| Variable                | Description                                                                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `NPM_TOKEN`             | Npm token created via [npm token create](https://docs.npmjs.com/getting-started/working_with_tokens#how-to-create-new-tokens) |
+| `NPM_USERNAME`          | Npm username created via [npm adduser](https://docs.npmjs.com/cli/adduser) or on [npmjs.com](https://www.npmjs.com)           |
+| `NPM_PASSWORD`          | Password of the npm user.                                                                                                     |
+| `NPM_EMAIL`             | Email address associated with the npm user                                                                                    |
+| `NPM_CONFIG_USERCONFIG` | Path to non-default .npmrc file                                                                                                 |
 
 Use either `NPM_TOKEN` for token authentication or `NPM_USERNAME`, `NPM_PASSWORD` and `NPM_EMAIL` for legacy authentication
 

--- a/lib/get-registry.js
+++ b/lib/get-registry.js
@@ -7,5 +7,9 @@ module.exports = ({publishConfig: {registry} = {}, name}, {cwd, env}) =>
   env.NPM_CONFIG_REGISTRY ||
   getRegistryUrl(
     name.split('/')[0],
-    rc('npm', {registry: 'https://registry.npmjs.org/'}, {config: path.resolve(cwd, '.npmrc')})
+    rc(
+      'npm',
+      {registry: 'https://registry.npmjs.org/'},
+      {config: env.NPM_CONFIG_USERCONFIG || path.resolve(cwd, '.npmrc')}
+    )
   );

--- a/test/get-registry.test.js
+++ b/test/get-registry.test.js
@@ -42,3 +42,21 @@ test('Get the registry configured in ".npmrc" for scoped package', async (t) => 
 
   t.is(getRegistry({name: '@scope/package-name'}, {cwd, env: {}}), 'https://custom3.registry.com/');
 });
+
+test.serial('Get the registry configured via "NPM_CONFIG_USERCONFIG" for scoped package', async (t) => {
+  const cwd = tempy.directory();
+  await appendFile(path.resolve(cwd, '.custom-npmrc'), '@scope:registry = https://custom4.registry.com');
+
+  t.is(
+    getRegistry(
+      {
+        name: '@scope/package-name',
+      },
+      {
+        cwd,
+        env: {NPM_CONFIG_USERCONFIG: path.resolve(cwd, '.custom-npmrc')},
+      }
+    ),
+    'https://custom4.registry.com/'
+  );
+});


### PR DESCRIPTION
Previously NPM_CONFIG_USERCONFIG was only used for getting the auth token and not used for actually getting the registry from .npmrc.

Fixes #349