### PR TITLE
docs: update README description to match code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The `npmPublish` and `tarballDir` option can be used to skip the publishing to t
 }
 ```
 
-When publishing from a sub-directory with the `pkgRoot` option, the `package.json` and `npm-shrinkwrap.json` updated with the new version can be moved to another directory with a `postpublish` [npm script](https://docs.npmjs.com/misc/scripts). For example with the [@semantic-release/git](https://github.com/semantic-release/git) plugin:
+When publishing from a sub-directory with the `pkgRoot` option, the `package.json` and `npm-shrinkwrap.json` updated with the new version can be moved to another directory with a `postversion`. For example with the [@semantic-release/git](https://github.com/semantic-release/git) plugin:
 
 ```json
 {


### PR DESCRIPTION
Even though the example shows
```json
{
  "scripts": {
    "postversion": "cp -r package.json .. && cp -r npm-shrinkwrap.json .."
  }
}
```
The description above it mentions using `postpublish` instead. I used `postpublish` in my workflow and ran into an issue where this hook is triggered _after_ [@semantic-release/git](https://github.com/semantic-release/git) determined what files to commit.
My exact situation was explained from the [FAQ](https://github.com/semantic-release/semantic-release/blob/master/docs/support/FAQ.md#how-can-i-use-a-npm-build-script-that-requires-the-packagejsons-version-) section, so I'm hoping to update the docs here.