### PR TITLE
fix: add `preferLocal` option to allow execa to use local npm version

### DIFF
--- a/lib/add-channel.js
+++ b/lib/add-channel.js
@@ -24,6 +24,7 @@ module.exports = async (npmrc, {npmPublish}, pkg, context) => {
       {
         cwd,
         env,
+        preferLocal: true,
       }
     );
     result.stdout.pipe(stdout, {end: false});

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -22,7 +22,7 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
 
   if (tarballDir) {
     logger.log('Creating npm package version %s', version);
-    const packResult = execa('npm', ['pack', basePath, '--userconfig', npmrc], {cwd, env});
+    const packResult = execa('npm', ['pack', basePath, '--userconfig', npmrc], {cwd, env, preferLocal: true});
     packResult.stdout.pipe(stdout, {end: false});
     packResult.stderr.pipe(stderr, {end: false});
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -23,7 +23,7 @@ module.exports = async (npmrc, {npmPublish, pkgRoot}, pkg, context) => {
     const result = execa(
       'npm',
       ['publish', basePath, '--userconfig', npmrc, '--tag', distTag, '--registry', registry],
-      {cwd, env}
+      {cwd, env, preferLocal: true}
     );
     result.stdout.pipe(stdout, {end: false});
     result.stderr.pipe(stderr, {end: false});

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -21,7 +21,7 @@ module.exports = async (npmrc, pkg, context) => {
       const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {
         cwd,
         env,
-        preferLocal: true
+        preferLocal: true,
       });
       whoamiResult.stdout.pipe(stdout, {end: false});
       whoamiResult.stderr.pipe(stderr, {end: false});

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -18,7 +18,11 @@ module.exports = async (npmrc, pkg, context) => {
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {
-      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {cwd, env, preferLocal: true});
+      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {
+        cwd,
+        env,
+        preferLocal: true
+      });
       whoamiResult.stdout.pipe(stdout, {end: false});
       whoamiResult.stderr.pipe(stderr, {end: false});
       await whoamiResult;

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -18,7 +18,7 @@ module.exports = async (npmrc, pkg, context) => {
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {
-      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {cwd, env});
+      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {cwd, env, preferLocal: true});
       whoamiResult.stdout.pipe(stdout, {end: false});
       whoamiResult.stderr.pipe(stderr, {end: false});
       await whoamiResult;


### PR DESCRIPTION
relates #434, #270 
alternative #444

From execa@2.0.0, `preferLocal` is set to `false` by default. The plugin uses `^5.0.0` now.

#177, 2 Jul 2019, execa 1.0.0 → 2.0.2

https://github.com/sindresorhus/execa/releases/tag/v2.0.0
sindresorhus/execa#314
sindresorhus/execa@eb22ff7