### PR TITLE
fix: add missed `preferLocal` option for execa call

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -13,6 +13,7 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
     {
       cwd: basePath,
       env,
+      preferLocal: true,
     }
   );
   versionResult.stdout.pipe(stdout, {end: false});


### PR DESCRIPTION
CC @travi 