### PR TITLE
fix: do not update workspaces when applying new version

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -9,7 +9,15 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
 
   const versionResult = execa(
     'npm',
-    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version'],
+    [
+      'version',
+      version,
+      '--userconfig',
+      npmrc,
+      '--no-git-tag-version',
+      '--allow-same-version',
+      '--no-workspaces-update',
+    ],
     {
       cwd: basePath,
       env,


### PR DESCRIPTION
In npm@8 the command `npm version` added a new command [workspaces-update](https://docs.npmjs.com/cli/v8/commands/npm-version#workspaces-update) which is `true` by default.
This option cause the following error when we install workspaces using non-released version (in this case the version `0.0.0-semantic-release`) :
> npm ERR! notarget No matching version found for package@0.0.0-semantic-release.