### PR TITLE
chore(npm-dependency): upgrades npm to 8.11.0 to resolve security vulnerability.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         node-version:
           - 14.17
           - 16.0.0
-          - 17
+          - 18
         os:
           - ubuntu-latest
     runs-on: "${{ matrix.os }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^8.3.0",
+        "npm": "^8.11.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.15",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^6.0.0",
-    "npm": "^8.3.0",
+    "npm": "^8.11.0",
     "rc": "^1.2.8",
     "read-pkg": "^5.0.0",
     "registry-auth-token": "^4.0.0",


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/mdombrowski1997'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/mdombrowski1997/tally.svg'></a>

* See https://github.com/advisories/GHSA-hj9c-8jmm-8c52
* Our team was made aware of that vulnerability by `yarn audit`, it does not show up in our dependabot alerts, which may be way it has not received an automatic PR from dependabot in this repo
* Our team is upgrading to semantic-release v19 to patch some other security alerts we've received from dependabot, and it'd be nice to patch this while we're in ugprading 