### PR TITLE
fix: Execute npm version with --workspaces=false

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -9,7 +9,7 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
 
   const versionResult = execa(
     'npm',
-    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version'],
+    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version', '--workspaces=false'],
     {
       cwd: basePath,
       env,


### PR DESCRIPTION
Some tools like https://github.com/qiwi/multi-semantic-release wrap semantic release. Unfortunately with newer versions of npm people started getting EUNSUPPORTEDPROTOCOL errors during version locking as described here: 

 - https://github.com/qiwi/multi-semantic-release/issues/60
 - https://github.com/dhoulb/multi-semantic-release/issues/129

This change just adds `--workspaces=false` to npm command during versioning. This parameter has not side effects on normal repos but fixes the issue for monorepo setups