### PR TITLE
fix: add --no-workspaces to npm whoami

### DIFF
--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -18,7 +18,7 @@ module.exports = async (npmrc, pkg, context) => {
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {
-      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {
+      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry, '--no-workspaces'], {
         cwd,
         env,
         preferLocal: true,


### PR DESCRIPTION
I'm using semantic-release with a monorepo which is not officially supported but discussed (e.g. https://github.com/semantic-release/semantic-release/issues/1688).

I've tried [various alternative](https://dev.to/antongolub/the-chronicles-of-semantic-release-and-monorepos-5cfc) but each of them gave me an uncomfortable feeling and after reading through https://github.com/semantic-release/npm/pull/482 I settled with the seemingly simple option of only using semantic-release together with this `.npmrc`: 

```
workspaces = true
workspaces-update = false
```

There's currently one issue blocking me from using this approach. Executing `npm whoami` with the above `.npmrc` yields an error, described in https://github.com/semantic-release/npm/issues/470.

This issue could be resolved by modifying `lib/verify-auth.js` slightly:

```diff
-      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry], {
+      const whoamiResult = execa('npm', ['whoami', '--userconfig', npmrc, '--registry', registry, '--no-workspaces'], {
```

The [NPM docs](https://docs.npmjs.com/cli/v9/using-npm/config#workspaces) mention:

> Explicitly setting this to false will cause commands like install to ignore workspaces altogether

I have verified that this flag has no adverse effect, running it on monorepos and non-monorepos both with and without the flag yield the same output. 