### PR TITLE
feat: additional arguments `publishArgs` and `versionArgs` for npm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Use either `NPM_TOKEN` for token authentication or `NPM_USERNAME`, `NPM_PASSWORD
 | `npmPublish` | Whether to publish the `npm` package to the registry. If `false` the `package.json` version will still be updated.  | `false` if the `package.json` [private](https://docs.npmjs.com/files/package.json#private) property is `true`, `true` otherwise. |
 | `pkgRoot`    | Directory path to publish.                                                                                          | `.`                                                                                                                              |
 | `tarballDir` | Directory path in which to write the package tarball. If `false` the tarball is not be kept on the file system. | `false`                                                                                                                          |
+| `publishArgs` | Additional arguments for executing the `npm publish` command. For example, to specify a workspace `['--workspace', 'packages']` | `[]`                                                                                                                          |
+| `versionArgs` | Additional arguments for executing the `npm version` command. For example, to specify a workspace `['--workspace', 'packages']` | `[]`                                                                                                                          |
 
 **Note**: The `pkgRoot` directory must contain a `package.json`. The version will be updated only in the `package.json` and `npm-shrinkwrap.json` within the `pkgRoot` directory.
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,15 +2,20 @@ const path = require('path');
 const {move} = require('fs-extra');
 const execa = require('execa');
 
-module.exports = async (npmrc, {tarballDir, pkgRoot, versionArgs}, {cwd, env, stdout, stderr, nextRelease: {version}, logger}) => {
+module.exports = async (
+  npmrc,
+  {tarballDir, pkgRoot, versionArgs},
+  {cwd, env, stdout, stderr, nextRelease: {version}, logger}
+) => {
   const basePath = pkgRoot ? path.resolve(cwd, pkgRoot) : cwd;
 
   logger.log('Write version %s to package.json in %s', version, basePath);
 
   const versionResult = execa(
     'npm',
-    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version']
-      .concat(versionArgs || []),
+    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version'].concat(
+      versionArgs || []
+    ),
     {
       cwd: basePath,
       env,

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,14 +2,15 @@ const path = require('path');
 const {move} = require('fs-extra');
 const execa = require('execa');
 
-module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr, nextRelease: {version}, logger}) => {
+module.exports = async (npmrc, {tarballDir, pkgRoot, versionArgs}, {cwd, env, stdout, stderr, nextRelease: {version}, logger}) => {
   const basePath = pkgRoot ? path.resolve(cwd, pkgRoot) : cwd;
 
   logger.log('Write version %s to package.json in %s', version, basePath);
 
   const versionResult = execa(
     'npm',
-    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version'],
+    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version']
+      .concat(versionArgs || []),
     {
       cwd: basePath,
       env,

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -4,7 +4,7 @@ const getRegistry = require('./get-registry');
 const getChannel = require('./get-channel');
 const getReleaseInfo = require('./get-release-info');
 
-module.exports = async (npmrc, {npmPublish, pkgRoot}, pkg, context) => {
+module.exports = async (npmrc, {npmPublish, pkgRoot, publishArgs}, pkg, context) => {
   const {
     cwd,
     env,
@@ -22,7 +22,8 @@ module.exports = async (npmrc, {npmPublish, pkgRoot}, pkg, context) => {
     logger.log(`Publishing version ${version} to npm registry on dist-tag ${distTag}`);
     const result = execa(
       'npm',
-      ['publish', basePath, '--userconfig', npmrc, '--tag', distTag, '--registry', registry],
+      ['publish', basePath, '--userconfig', npmrc, '--tag', distTag, '--registry', registry]
+        .concat(publishArgs || []),
       {cwd, env, preferLocal: true}
     );
     result.stdout.pipe(stdout, {end: false});

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -22,8 +22,7 @@ module.exports = async (npmrc, {npmPublish, pkgRoot, publishArgs}, pkg, context)
     logger.log(`Publishing version ${version} to npm registry on dist-tag ${distTag}`);
     const result = execa(
       'npm',
-      ['publish', basePath, '--userconfig', npmrc, '--tag', distTag, '--registry', registry]
-        .concat(publishArgs || []),
+      ['publish', basePath, '--userconfig', npmrc, '--tag', distTag, '--registry', registry].concat(publishArgs || []),
       {cwd, env, preferLocal: true}
     );
     result.stdout.pipe(stdout, {end: false});


### PR DESCRIPTION
- #512 
- #529

I built my own [monorepo ecosystem](https://github.com/1aron/aronrepo/tree/beta/packages/semantic-release-config) based on semantic release.

During the NPM release process, I encountered resistance, so I added two conservative features.

Since specifying a workspace in `.npmrc` such as `workspace=packages` will change the behavior of executing `npm run` in the root directory, we usually don't want to store `.npmrc`, and NPM will not automatically read the `.workspaces` settings in package.json when running `npm publish` and `npm version`, which is quite inconvenient.

Of course, we can execute `echo -e "\nworkspace=packages/**/*" >> .npmrc` on CI, but as mentioned above, it will affect the execution of subsequent instructions, which will make the command of the project not predictable.

Before submitting this PR I removed `@semantic-release/npm` package and solved my problem in `publishCmd`:
```json
{
     "publishCmd": "npm publish --workspace=packages"
}
```
But I found that I was missing a lot of the benefits that `@semantic-release/npm` brought me.

You can see the use cases I added in the README:
```json
{
     "publishArgs": ["--workspace", "packages"],
     "versionArgs": ["--workspace", "packages"]
}
```

These test cases were failing before I made any changes:

<img width="770" alt="Screenshot 2022-12-08 at 12 07 57 AM" src="https://user-images.githubusercontent.com/33840671/206230445-ae0b9694-c226-46e0-8bc8-0d5baacb792e.png">

I even use it on the [Master CSS](https://github.com/master-co/css) open source project, which is a monorepo, and it works nicely with Semantic Release.

This is not a monorepo-specific feature, but this can be very useful in monorepo projects with multiple packages. Hope this feature passes quickly, thanks to the Semantic Release team for all you do.

