### PR TITLE
upgrade dependencies that are now unblocked after the esm transition

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ export async function verifyConditions(pluginConfig, context) {
       await verifyNpmAuth(npmrc, pkg, context);
     }
   } catch (error) {
-    errors.push(...error);
+    errors.push(...error.errors);
   }
 
   if (errors.length > 0) {
@@ -53,7 +53,7 @@ export async function prepare(pluginConfig, context) {
       await verifyNpmAuth(npmrc, pkg, context);
     }
   } catch (error) {
-    errors.push(...error);
+    errors.push(...error.errors);
   }
 
   if (errors.length > 0) {
@@ -75,7 +75,7 @@ export async function publish(pluginConfig, context) {
       await verifyNpmAuth(npmrc, pkg, context);
     }
   } catch (error) {
-    errors.push(...error);
+    errors.push(...error.errors);
   }
 
   if (errors.length > 0) {
@@ -100,7 +100,7 @@ export async function addChannel(pluginConfig, context) {
       await verifyNpmAuth(npmrc, pkg, context);
     }
   } catch (error) {
-    errors.push(...error);
+    errors.push(...error.errors);
   }
 
   if (errors.length > 0) {

--- a/lib/add-channel.js
+++ b/lib/add-channel.js
@@ -1,4 +1,4 @@
-import execa from "execa";
+import { execa } from "execa";
 import getRegistry from "./get-registry.js";
 import getChannel from "./get-channel.js";
 import getReleaseInfo from "./get-release-info.js";

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,6 +1,6 @@
 import path from "path";
 import { move } from "fs-extra";
-import execa from "execa";
+import { execa } from "execa";
 
 export default async function (
   npmrc,

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,5 +1,5 @@
 import path from "path";
-import execa from "execa";
+import { execa } from "execa";
 import getRegistry from "./get-registry.js";
 import getChannel from "./get-channel.js";
 import getReleaseInfo from "./get-release-info.js";

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -1,4 +1,4 @@
-import execa from "execa";
+import { execa } from "execa";
 import normalizeUrl from "normalize-url";
 import AggregateError from "aggregate-error";
 import getError from "./get-error.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
+        "normalize-url": "^8.0.0",
         "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^7.0.0",
@@ -597,6 +597,18 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
@@ -1399,18 +1411,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/normalize-url": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/callsites": {
@@ -3854,10 +3854,11 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "license": "MIT",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8862,6 +8863,12 @@
             }
           }
         },
+        "normalize-url": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+          "dev": true
+        },
         "npm-run-path": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -9392,14 +9399,6 @@
         "mimic-response": "^4.0.0",
         "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
-          "dev": true
-        }
       }
     },
     "callsites": {
@@ -10963,7 +10962,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "6.1.0"
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw=="
     },
     "npm": {
       "version": "8.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
+        "aggregate-error": "^4.0.1",
         "execa": "^6.1.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
@@ -410,6 +410,28 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
+    "node_modules/@semantic-release/github/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@semantic-release/github/node_modules/globby": {
       "version": "11.1.0",
       "dev": true,
@@ -466,6 +488,28 @@
       },
       "peerDependencies": {
         "semantic-release": ">=19.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/crypto-random-string": {
@@ -815,14 +859,29 @@
       }
     },
     "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "license": "MIT",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
       "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1487,10 +1546,17 @@
       "license": "MIT"
     },
     "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clean-yaml-object": {
@@ -2018,6 +2084,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/del/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/del/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/del/node_modules/globby": {
       "version": "11.1.0",
       "dev": true,
@@ -2302,7 +2390,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2958,6 +3045,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6293,46 +6381,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map/node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map/node_modules/clean-stack": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map/node_modules/indent-string": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-reduce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
@@ -7072,6 +7120,19 @@
         "node": ">=16 || ^14.17"
       }
     },
+    "node_modules/semantic-release/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/semantic-release/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7079,6 +7140,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/semantic-release/node_modules/cliui": {
@@ -8653,6 +8723,22 @@
           "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
           "dev": true
         },
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "globby": {
           "version": "11.1.0",
           "dev": true,
@@ -8696,6 +8782,22 @@
         "tempy": "^1.0.0"
       },
       "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "crypto-random-string": {
           "version": "2.0.0",
           "dev": true
@@ -8942,10 +9044,19 @@
       }
     },
     "aggregate-error": {
-      "version": "3.1.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
       "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+        }
       }
     },
     "ansi-escapes": {
@@ -9364,7 +9475,12 @@
       "dev": true
     },
     "clean-stack": {
-      "version": "2.2.0"
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "requires": {
+        "escape-string-regexp": "5.0.0"
+      }
     },
     "clean-yaml-object": {
       "version": "0.1.0",
@@ -9708,6 +9824,22 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
         "globby": {
           "version": "11.1.0",
           "dev": true,
@@ -9909,8 +10041,7 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "5.0.0",
-      "dev": true
+      "version": "5.0.0"
     },
     "esprima": {
       "version": "4.0.1",
@@ -10339,7 +10470,8 @@
       "dev": true
     },
     "indent-string": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -12498,27 +12630,6 @@
       "dev": true,
       "requires": {
         "aggregate-error": "^4.0.0"
-      },
-      "dependencies": {
-        "aggregate-error": {
-          "version": "4.0.1",
-          "dev": true,
-          "requires": {
-            "clean-stack": "^4.0.0",
-            "indent-string": "^5.0.0"
-          }
-        },
-        "clean-stack": {
-          "version": "4.2.0",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "5.0.0"
-          }
-        },
-        "indent-string": {
-          "version": "5.0.0",
-          "dev": true
-        }
       }
     },
     "p-reduce": {
@@ -12953,10 +13064,26 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
           "dev": true
         },
         "cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
+        "execa": "^6.1.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
@@ -457,6 +457,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/@semantic-release/npm/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/@semantic-release/npm/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -476,6 +499,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@semantic-release/npm/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
       "version": "2.5.0",
       "dev": true,
@@ -493,6 +534,33 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/read-pkg": {
@@ -519,6 +587,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/tempy": {
@@ -2150,6 +2227,83 @@
         "node": ">=10.17"
       }
     },
+    "node_modules/env-ci/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/env-ci/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/env-ci/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/env-ci/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/env-ci/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "license": "MIT",
@@ -2197,24 +2351,36 @@
       }
     },
     "node_modules/execa": {
-      "version": "5.1.1",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-diff": {
@@ -2702,10 +2868,11 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "2.1.0",
-      "license": "Apache-2.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/ieee754": {
@@ -2959,6 +3126,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3430,7 +3598,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3772,13 +3939,28 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "license": "MIT",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
       "dependencies": {
-        "path-key": "^3.0.0"
+        "path-key": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/@colors/colors": {
@@ -5983,23 +6165,17 @@
       }
     },
     "node_modules/onetime": {
-      "version": "5.1.2",
-      "license": "MIT",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dependencies": {
-        "mimic-fn": "^2.1.0"
+        "mimic-fn": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onetime/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-cancelable": {
@@ -6917,6 +7093,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/semantic-release/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/semantic-release/node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -6932,6 +7131,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/semantic-release/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/semantic-release/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6939,6 +7147,42 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/string-width": {
@@ -6965,6 +7209,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/semantic-release/node_modules/yargs": {
@@ -7515,10 +7768,14 @@
       }
     },
     "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -8431,6 +8688,23 @@
           "version": "2.0.0",
           "dev": true
         },
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -8444,6 +8718,18 @@
         },
         "hosted-git-info": {
           "version": "2.8.9",
+          "dev": true
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "normalize-package-data": {
@@ -8460,6 +8746,24 @@
               "version": "5.7.1",
               "dev": true
             }
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
           }
         },
         "read-pkg": {
@@ -8480,6 +8784,12 @@
           "requires": {
             "rc": "1.2.8"
           }
+        },
+        "strip-final-newline": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+          "dev": true
         },
         "tempy": {
           "version": "1.0.1",
@@ -9541,6 +9851,61 @@
         "execa": "^5.0.0",
         "fromentries": "^1.3.2",
         "java-properties": "^1.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "strip-final-newline": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+          "dev": true
+        }
       }
     },
     "error-ex": {
@@ -9566,17 +9931,26 @@
       "dev": true
     },
     "execa": {
-      "version": "5.1.1",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
       "requires": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+        }
       }
     },
     "fast-diff": {
@@ -9911,7 +10285,9 @@
       }
     },
     "human-signals": {
-      "version": "2.1.0"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -10054,7 +10430,8 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "is-text-path": {
       "version": "1.0.1",
@@ -10342,8 +10719,7 @@
       "dev": true
     },
     "mimic-fn": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -12024,9 +12400,18 @@
       }
     },
     "npm-run-path": {
-      "version": "4.0.1",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
       "requires": {
-        "path-key": "^3.0.0"
+        "path-key": "^4.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+        }
       }
     },
     "once": {
@@ -12037,14 +12422,11 @@
       }
     },
     "onetime": {
-      "version": "5.1.2",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "requires": {
-        "mimic-fn": "^2.1.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0"
-        }
+        "mimic-fn": "^4.0.0"
       }
     },
     "p-cancelable": {
@@ -12580,6 +12962,23 @@
           "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
         "figures": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -12589,11 +12988,41 @@
             "escape-string-regexp": "^1.0.5"
           }
         },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
         },
         "string-width": {
           "version": "4.2.3",
@@ -12614,6 +13043,12 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
+        },
+        "strip-final-newline": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+          "dev": true
         },
         "yargs": {
           "version": "16.2.0",
@@ -12996,7 +13431,9 @@
       "dev": true
     },
     "strip-final-newline": {
-      "version": "2.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
     },
     "strip-indent": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,11 +30,11 @@
         "delay": "5.0.0",
         "dockerode": "3.3.4",
         "get-stream": "6.0.1",
-        "got": "11.8.6",
-        "p-retry": "4.6.2",
+        "got": "12.5.3",
+        "p-retry": "5.1.2",
         "prettier": "^2.8.2",
         "semantic-release": "19.0.5",
-        "sinon": "14.0.2",
+        "sinon": "15.0.1",
         "stream-buffers": "3.0.2"
       },
       "engines": {
@@ -404,6 +404,12 @@
         "semantic-release": ">=18.0.0-beta.1"
       }
     },
+    "node_modules/@semantic-release/github/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
     "node_modules/@semantic-release/github/node_modules/globby": {
       "version": "11.1.0",
       "dev": true,
@@ -421,6 +427,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -670,11 +689,12 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+      "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -713,14 +733,15 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -731,42 +752,19 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "18.11.18",
       "dev": true,
       "license": "MIT"
     },
@@ -780,18 +778,11 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -1325,39 +1316,39 @@
       }
     },
     "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=10.6.0"
+        "node": ">=14.16"
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.2",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.5.tgz",
+      "integrity": "sha512-5RwYYCfzjNPsyJxb/QpaM0bfzx+kw5/YpDhZPm9oMIDntHFQ9YXeyV47ZvzlTE0XrrrbyO2UITJH4GF9eRLdXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
+        "@types/http-cache-semantics": "^4.0.1",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.0",
+        "keyv": "^4.5.2",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
+    "node_modules/cacheable-request/node_modules/normalize-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1640,17 +1631,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/code-excerpt": {
@@ -2010,8 +1990,9 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -2488,6 +2469,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "dev": true,
@@ -2728,24 +2718,25 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.6",
+      "version": "12.5.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.5.3.tgz",
+      "integrity": "sha512-8wKnb9MGU8IPGRIo+/ukTy9XLJBwDiCpIf5TVzQ9Cpol50eMTpBq2GAuDsuDIz7hTYmZgMgC1e9ydr6kSDWs3w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.1",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.19.0"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -2827,8 +2818,9 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -2844,12 +2836,13 @@
       }
     },
     "node_modules/http2-wrapper": {
-      "version": "1.0.3",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       },
       "engines": {
         "node": ">=10.19.0"
@@ -3250,8 +3243,9 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -3307,8 +3301,9 @@
     },
     "node_modules/keyv": {
       "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3395,11 +3390,15 @@
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -3607,11 +3606,15 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -6179,11 +6182,12 @@
       }
     },
     "node_modules/p-cancelable": {
-      "version": "2.1.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
       }
     },
     "node_modules/p-defer": {
@@ -6339,15 +6343,19 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.2",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.0",
+        "@types/retry": "0.12.1",
         "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -6669,8 +6677,9 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6906,8 +6915,9 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -6929,11 +6939,15 @@
       }
     },
     "node_modules/responselike": {
-      "version": "2.0.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7505,13 +7519,13 @@
       }
     },
     "node_modules/sinon": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-      "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/fake-timers": "10.0.2",
         "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
         "nise": "^5.1.2",
@@ -7520,24 +7534,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
       }
     },
     "node_modules/slash": {
@@ -8651,6 +8647,12 @@
         "url-join": "^4.0.0"
       },
       "dependencies": {
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
+        },
         "globby": {
           "version": "11.1.0",
           "dev": true,
@@ -8661,6 +8663,16 @@
             "ignore": "^5.2.0",
             "merge2": "^1.4.1",
             "slash": "^3.0.0"
+          }
+        },
+        "p-retry": {
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+          "dev": true,
+          "requires": {
+            "@types/retry": "0.12.0",
+            "retry": "^0.13.1"
           }
         }
       }
@@ -8838,7 +8850,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "4.6.0",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+      "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -8871,47 +8885,30 @@
       "dev": true
     },
     "@szmarczak/http-timer": {
-      "version": "4.0.6",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
       "requires": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       }
     },
     "@tootallnate/once": {
       "version": "2.0.0",
       "dev": true
     },
-    "@types/cacheable-request": {
-      "version": "6.0.3",
-      "dev": true,
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true
     },
-    "@types/keyv": {
-      "version": "3.1.4",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.2",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "18.11.18",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -8923,15 +8920,10 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
-    "@types/responselike": {
-      "version": "1.0.0",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/retry": {
-      "version": "0.12.0",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
     "acorn": {
@@ -9271,28 +9263,31 @@
       }
     },
     "cacheable-lookup": {
-      "version": "5.0.4",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true
     },
     "cacheable-request": {
-      "version": "7.0.2",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.5.tgz",
+      "integrity": "sha512-5RwYYCfzjNPsyJxb/QpaM0bfzx+kw5/YpDhZPm9oMIDntHFQ9YXeyV47ZvzlTE0XrrrbyO2UITJH4GF9eRLdXQ==",
       "dev": true,
       "requires": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
+        "@types/http-cache-semantics": "^4.0.1",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.0",
+        "keyv": "^4.5.2",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
+        "normalize-url": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+          "dev": true
         }
       }
     },
@@ -9458,13 +9453,6 @@
             "ansi-regex": "^5.0.1"
           }
         }
-      }
-    },
-    "clone-response": {
-      "version": "1.0.3",
-      "dev": true,
-      "requires": {
-        "mimic-response": "^1.0.0"
       }
     },
     "code-excerpt": {
@@ -9702,6 +9690,8 @@
     },
     "defer-to-connect": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true
     },
     "del": {
@@ -10024,6 +10014,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true
+    },
     "from2": {
       "version": "2.3.0",
       "dev": true,
@@ -10195,20 +10191,22 @@
       }
     },
     "got": {
-      "version": "11.8.6",
+      "version": "12.5.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.5.3.tgz",
+      "integrity": "sha512-8wKnb9MGU8IPGRIo+/ukTy9XLJBwDiCpIf5TVzQ9Cpol50eMTpBq2GAuDsuDIz7hTYmZgMgC1e9ydr6kSDWs3w==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.1",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -10257,6 +10255,8 @@
     },
     "http-cache-semantics": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -10269,11 +10269,13 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.3",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       }
     },
     "https-proxy-agent": {
@@ -10508,6 +10510,8 @@
     },
     "json-buffer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -10546,6 +10550,8 @@
     },
     "keyv": {
       "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dev": true,
       "requires": {
         "json-buffer": "3.0.1"
@@ -10605,7 +10611,9 @@
       "dev": true
     },
     "lowercase-keys": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true
     },
     "lru-cache": {
@@ -10722,7 +10730,9 @@
       "version": "4.0.0"
     },
     "mimic-response": {
-      "version": "1.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true
     },
     "min-indent": {
@@ -12430,7 +12440,9 @@
       }
     },
     "p-cancelable": {
-      "version": "2.1.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true
     },
     "p-defer": {
@@ -12516,10 +12528,12 @@
       "dev": true
     },
     "p-retry": {
-      "version": "4.6.2",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
       "dev": true,
       "requires": {
-        "@types/retry": "0.12.0",
+        "@types/retry": "0.12.1",
         "retry": "^0.13.1"
       }
     },
@@ -12695,6 +12709,8 @@
     },
     "quick-lru": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
     "rc": {
@@ -12847,6 +12863,8 @@
     },
     "resolve-alpn": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true
     },
     "resolve-cwd": {
@@ -12861,10 +12879,12 @@
       "dev": true
     },
     "responselike": {
-      "version": "2.0.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
       }
     },
     "retry": {
@@ -13234,39 +13254,17 @@
       }
     },
     "sinon": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-      "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/fake-timers": "10.0.2",
         "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
         "nise": "^5.1.2",
         "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "@sinonjs/fake-timers": {
-          "version": "9.1.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-          "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          },
-          "dependencies": {
-            "@sinonjs/commons": {
-              "version": "1.8.6",
-              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-              "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-              "dev": true,
-              "requires": {
-                "type-detect": "4.0.8"
-              }
-            }
-          }
-        }
       }
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@semantic-release/error": "^3.0.0",
-    "aggregate-error": "^3.0.0",
+    "aggregate-error": "^4.0.1",
     "execa": "^6.1.0",
     "fs-extra": "^11.0.0",
     "lodash-es": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fs-extra": "^11.0.0",
     "lodash-es": "^4.17.21",
     "nerf-dart": "^1.0.0",
-    "normalize-url": "^6.0.0",
+    "normalize-url": "^8.0.0",
     "npm": "^8.3.0",
     "rc": "^1.2.8",
     "read-pkg": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@semantic-release/error": "^3.0.0",
     "aggregate-error": "^3.0.0",
-    "execa": "^5.0.0",
+    "execa": "^6.1.0",
     "fs-extra": "^11.0.0",
     "lodash-es": "^4.17.21",
     "nerf-dart": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "delay": "5.0.0",
     "dockerode": "3.3.4",
     "get-stream": "6.0.1",
-    "got": "11.8.6",
-    "p-retry": "4.6.2",
+    "got": "12.5.3",
+    "p-retry": "5.1.2",
     "prettier": "^2.8.2",
     "semantic-release": "19.0.5",
-    "sinon": "14.0.2",
+    "sinon": "15.0.1",
     "stream-buffers": "3.0.2"
   },
   "engines": {

--- a/test/get-pkg.test.js
+++ b/test/get-pkg.test.js
@@ -27,7 +27,9 @@ test("Verify name and version then return parsed package.json from a sub-directo
 
 test("Throw error if missing package.json", async (t) => {
   const cwd = temporaryDirectory();
-  const [error] = await t.throwsAsync(getPkg({}, { cwd }));
+  const {
+    errors: [error],
+  } = await t.throwsAsync(getPkg({}, { cwd }));
 
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "ENOPKG");
@@ -37,7 +39,9 @@ test("Throw error if missing package name", async (t) => {
   const cwd = temporaryDirectory();
   await fs.outputJson(path.resolve(cwd, "package.json"), { version: "0.0.0" });
 
-  const [error] = await t.throwsAsync(getPkg({}, { cwd }));
+  const {
+    errors: [error],
+  } = await t.throwsAsync(getPkg({}, { cwd }));
 
   t.is(error.name, "SemanticReleaseError");
   t.is(error.code, "ENOPKGNAME");
@@ -47,7 +51,9 @@ test("Throw error if package.json is malformed", async (t) => {
   const cwd = temporaryDirectory();
   await fs.writeFile(path.resolve(cwd, "package.json"), "{name: 'package',}");
 
-  const [error] = await t.throwsAsync(getPkg({}, { cwd }));
+  const {
+    errors: [error],
+  } = await t.throwsAsync(getPkg({}, { cwd }));
 
   t.is(error.name, "JSONError");
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -96,7 +96,9 @@ test("Throws error if NPM token is invalid", async (t) => {
   const pkg = { name: "published", version: "1.0.0", publishConfig: { registry: npmRegistry.url } };
   await fs.outputJson(path.resolve(cwd, "package.json"), pkg);
 
-  const [error] = await t.throwsAsync(
+  const {
+    errors: [error],
+  } = await t.throwsAsync(
     t.context.m.verifyConditions(
       {},
       { cwd, env, options: {}, stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger }
@@ -186,21 +188,23 @@ test("Throw SemanticReleaseError Array if config option are not valid in verifyC
   const tarballDir = 42;
   const pkgRoot = 42;
   const errors = [
-    ...(await t.throwsAsync(
-      t.context.m.verifyConditions(
-        {},
-        {
-          cwd,
-          env: {},
-          options: {
-            publish: ["@semantic-release/github", { path: "@semantic-release/npm", npmPublish, tarballDir, pkgRoot }],
-          },
-          stdout: t.context.stdout,
-          stderr: t.context.stderr,
-          logger: t.context.logger,
-        }
+    ...(
+      await t.throwsAsync(
+        t.context.m.verifyConditions(
+          {},
+          {
+            cwd,
+            env: {},
+            options: {
+              publish: ["@semantic-release/github", { path: "@semantic-release/npm", npmPublish, tarballDir, pkgRoot }],
+            },
+            stdout: t.context.stdout,
+            stderr: t.context.stderr,
+            logger: t.context.logger,
+          }
+        )
       )
-    )),
+    ).errors,
   ];
 
   t.is(errors[0].name, "SemanticReleaseError");
@@ -411,20 +415,22 @@ test("Throw SemanticReleaseError Array if config option are not valid in publish
   const pkgRoot = 42;
 
   const errors = [
-    ...(await t.throwsAsync(
-      t.context.m.publish(
-        { npmPublish, tarballDir, pkgRoot },
-        {
-          cwd,
-          env: {},
-          options: { publish: ["@semantic-release/github", "@semantic-release/npm"] },
-          nextRelease: { version: "1.0.0" },
-          stdout: t.context.stdout,
-          stderr: t.context.stderr,
-          logger: t.context.logger,
-        }
+    ...(
+      await t.throwsAsync(
+        t.context.m.publish(
+          { npmPublish, tarballDir, pkgRoot },
+          {
+            cwd,
+            env: {},
+            options: { publish: ["@semantic-release/github", "@semantic-release/npm"] },
+            nextRelease: { version: "1.0.0" },
+            stdout: t.context.stdout,
+            stderr: t.context.stderr,
+            logger: t.context.logger,
+          }
+        )
       )
-    )),
+    ).errors,
   ];
 
   t.is(errors[0].name, "SemanticReleaseError");
@@ -492,20 +498,22 @@ test("Throw SemanticReleaseError Array if config option are not valid in prepare
   const pkgRoot = 42;
 
   const errors = [
-    ...(await t.throwsAsync(
-      t.context.m.prepare(
-        { npmPublish, tarballDir, pkgRoot },
-        {
-          cwd,
-          env: {},
-          options: { publish: ["@semantic-release/github", "@semantic-release/npm"] },
-          nextRelease: { version: "1.0.0" },
-          stdout: t.context.stdout,
-          stderr: t.context.stderr,
-          logger: t.context.logger,
-        }
+    ...(
+      await t.throwsAsync(
+        t.context.m.prepare(
+          { npmPublish, tarballDir, pkgRoot },
+          {
+            cwd,
+            env: {},
+            options: { publish: ["@semantic-release/github", "@semantic-release/npm"] },
+            nextRelease: { version: "1.0.0" },
+            stdout: t.context.stdout,
+            stderr: t.context.stderr,
+            logger: t.context.logger,
+          }
+        )
       )
-    )),
+    ).errors,
   ];
 
   t.is(errors[0].name, "SemanticReleaseError");
@@ -677,20 +685,22 @@ test("Throw SemanticReleaseError Array if config option are not valid in addChan
   const pkgRoot = 42;
 
   const errors = [
-    ...(await t.throwsAsync(
-      t.context.m.addChannel(
-        { npmPublish, tarballDir, pkgRoot },
-        {
-          cwd,
-          env,
-          options: { publish: ["@semantic-release/github", "@semantic-release/npm"] },
-          nextRelease: { version: "1.0.0" },
-          stdout: t.context.stdout,
-          stderr: t.context.stderr,
-          logger: t.context.logger,
-        }
+    ...(
+      await t.throwsAsync(
+        t.context.m.addChannel(
+          { npmPublish, tarballDir, pkgRoot },
+          {
+            cwd,
+            env,
+            options: { publish: ["@semantic-release/github", "@semantic-release/npm"] },
+            nextRelease: { version: "1.0.0" },
+            stdout: t.context.stdout,
+            stderr: t.context.stderr,
+            logger: t.context.logger,
+          }
+        )
       )
-    )),
+    ).errors,
   ];
 
   t.is(errors[0].name, "SemanticReleaseError");

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,7 @@
 import path from "path";
 import test from "ava";
 import fs from "fs-extra";
-import execa from "execa";
+import { execa } from "execa";
 import { spy } from "sinon";
 import { temporaryDirectory } from "tempy";
 import { WritableStreamBuffer } from "stream-buffers";

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -2,7 +2,7 @@ import path from "path";
 import test from "ava";
 import fs from "fs-extra";
 import { temporaryDirectory, temporaryFile } from "tempy";
-import execa from "execa";
+import { execa } from "execa";
 import { stub } from "sinon";
 import { WritableStreamBuffer } from "stream-buffers";
 import prepare from "../lib/prepare.js";

--- a/test/set-npmrc-auth.test.js
+++ b/test/set-npmrc-auth.test.js
@@ -117,7 +117,9 @@ test.serial('Throw error if "NPM_TOKEN" is missing', async (t) => {
   const npmrc = temporaryFile({ name: ".npmrc" });
 
   const setNpmrcAuth = (await import("../lib/set-npmrc-auth.js")).default;
-  const [error] = await t.throwsAsync(
+  const {
+    errors: [error],
+  } = await t.throwsAsync(
     setNpmrcAuth(npmrc, "http://custom.registry.com", { cwd, env: {}, logger: t.context.logger })
   );
 


### PR DESCRIPTION
this PR should be integrated with a normal merge since these are independent updates of various impacts rather than being a single atomic change