### PR TITLE
raised the peer requirement for semantic-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "semantic-release": ">=19.0.0"
+        "semantic-release": ">=20.1.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=19.0.0"
+    "semantic-release": ">=20.1.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
this is a breaking change to add to the list of breakages for this beta. using a normal merge already includes the token to consider as a breakage

before we decide to merge this though, i think this is a chance to consider https://github.com/semantic-release/semantic-release/pull/2670#discussion_r1070214972 first. the options to decide between, as i see them, are:

* merge this PR that raises the peer requirement to the first beta of core that supports loading esm plugins, promote the beta of core still depending on a beta of the npm plugin, then raise the peer again to v21 that has been promoted to stable, and finally promote the npm plugin to stable
* backport the support for loading esm plugins to v20 of core, update the peer requirement here to the v20 version that supports esm plugins, promote the npm plugin to stable, promote core to stable