### PR TITLE
fix: add --no-workspaces to npm version command in prepare

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -13,7 +13,7 @@ export default async function (
 
   const versionResult = execa(
     "npm",
-    ["version", version, "--userconfig", npmrc, "--no-git-tag-version", "--allow-same-version"],
+    ["version", version, "--userconfig", npmrc, "--no-git-tag-version", "--allow-same-version", "--no-workspaces"],
     {
       cwd: basePath,
       env,


### PR DESCRIPTION
Allow the prepare command to work in workspaces