### PR TITLE
test(integration): properly waited for the image pull to complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "c8": "8.0.0",
         "codecov": "3.8.3",
         "dockerode": "3.3.5",
-        "get-stream": "7.0.0",
         "got": "13.0.0",
         "p-retry": "5.1.2",
         "prettier": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "c8": "8.0.0",
     "codecov": "3.8.3",
     "dockerode": "3.3.5",
-    "get-stream": "7.0.0",
     "got": "13.0.0",
     "p-retry": "5.1.2",
     "prettier": "2.8.8",

--- a/test/helpers/npm-registry.js
+++ b/test/helpers/npm-registry.js
@@ -2,7 +2,6 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { setTimeout } from "node:timers/promises";
 import Docker from "dockerode";
-import getStream from "get-stream";
 import got from "got";
 import path from "path";
 import pRetry from "p-retry";
@@ -22,7 +21,10 @@ let container, npmToken;
  * Download the `npm-registry-docker` Docker image, create a new container and start it.
  */
 export async function start() {
-  await getStream(await docker.pull(IMAGE));
+  const stream = await docker.pull(IMAGE);
+  await new Promise((resolve, reject) => {
+    docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+  });
 
   container = await docker.createContainer({
     Tty: true,


### PR DESCRIPTION
this uses the technique for waiting for the pull to complete [from the dockerode readme](https://github.com/apocas/dockerode/tree/edf29ccb2c2c7bfcdd1cf3cacbe861bd0f4bc87a#helper-functions) and gets rid of our dependence on get-stream