### PR TITLE
feat: add pnpm support via `packageManager` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Refer to the [GitHub Actions recipe for npm package provenance](https://semantic
 | `npmPublish` | Whether to publish the `npm` package to the registry. If `false` the `package.json` version will still be updated. | `false` if the `package.json` [private](https://docs.npmjs.com/files/package.json#private) property is `true`, `true` otherwise. |
 | `pkgRoot`    | Directory path to publish.                                                                                         | `.`                                                                                                                              |
 | `tarballDir` | Directory path in which to write the package tarball. If `false` the tarball is not be kept on the file system.    | `false`                                                                                                                          |
+| `packageManager` | Package manager used to publish the package (`npm` and `pnpm` are supported).    | `npm`                                                                                                                          |
 
 **Note**: The `pkgRoot` directory must contain a `package.json`. The version will be updated only in the `package.json` and `npm-shrinkwrap.json` within the `pkgRoot` directory.
 

--- a/index.js
+++ b/index.js
@@ -18,9 +18,10 @@ export async function verifyConditions(pluginConfig, context) {
     const publishPlugin =
       castArray(context.options.publish).find((config) => config.path && config.path === "@semantic-release/npm") || {};
 
-    pluginConfig.npmPublish = defaultTo(pluginConfig.npmPublish, publishPlugin.npmPublish);
-    pluginConfig.tarballDir = defaultTo(pluginConfig.tarballDir, publishPlugin.tarballDir);
-    pluginConfig.pkgRoot = defaultTo(pluginConfig.pkgRoot, publishPlugin.pkgRoot);
+    pluginConfig.npmPublish = pluginConfig.npmPublish ?? publishPlugin.npmPublish;
+    pluginConfig.tarballDir = pluginConfig.tarballDir ?? publishPlugin.tarballDir;
+    pluginConfig.pkgRoot = pluginConfig.pkgRoot ?? publishPlugin.pkgRoot;
+    pluginConfig.packageManager = pluginConfig.packageManager ?? publishPlugin.packageManager ?? 'npm';
   }
 
   const errors = verifyNpmConfig(pluginConfig);
@@ -30,7 +31,7 @@ export async function verifyConditions(pluginConfig, context) {
 
     // Verify the npm authentication only if `npmPublish` is not false and `pkg.private` is not `true`
     if (pluginConfig.npmPublish !== false && pkg.private !== true) {
-      await verifyNpmAuth(npmrc, pkg, context);
+      await verifyNpmAuth(npmrc, pkg, context, pluginConfig.packageManager);
     }
   } catch (error) {
     errors.push(...error.errors);

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -34,6 +34,15 @@ Your configuration for the \`pkgRoot\` option is \`${pkgRoot}\`.`,
   };
 }
 
+export function EINVALIDPACKAGEMANAGER({ packageManager }) {
+  return {
+    message: "Invalid `packageManager` option.",
+    details: `The [packageManager option](${linkify("README.md#packageManager")}) option, if defined, must be a \`String\`.
+
+Your configuration for the \`packageManager\` option is \`${packageManager}\`.`,
+  };
+}
+
 export function ENONPMTOKEN({ registry }) {
   return {
     message: "No npm token specified.",

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -10,13 +10,9 @@ export default async function (
   const basePath = pkgRoot ? path.resolve(cwd, pkgRoot) : cwd;
 
   logger.log("Write version %s to package.json in %s", version, basePath);
-  const commandOptions = packageManager === 'npm'
-    ? ["version", version, "--userconfig", npmrc, "--no-git-tag-version", "--allow-same-version"]
-    : ["version", version, "--config", npmrc, "--no-git-tag-version", "--allow-same-version"];
-
   const versionResult = execa(
     packageManager,
-    commandOptions,
+    ["version", version, "--userconfig", npmrc, "--no-git-tag-version", "--allow-same-version"],
     {
       cwd: basePath,
       env,
@@ -30,10 +26,7 @@ export default async function (
 
   if (tarballDir) {
     logger.log("Creating npm package version %s", version);
-    const commandOptions = packageManager === 'npm'
-      ? ["pack", basePath, "--userconfig", npmrc]
-      : ["pack", basePath, "--config", npmrc];
-    const packResult = execa(packageManager, commandOptions, { cwd, env, preferLocal: true });
+    const packResult = execa(packageManager, ["pack", basePath, "--userconfig", npmrc], { cwd, env, preferLocal: true });
     packResult.stdout.pipe(stdout, { end: false });
     packResult.stderr.pipe(stderr, { end: false });
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -4,16 +4,19 @@ import { execa } from "execa";
 
 export default async function (
   npmrc,
-  { tarballDir, pkgRoot },
+  { tarballDir, pkgRoot, packageManager },
   { cwd, env, stdout, stderr, nextRelease: { version }, logger }
 ) {
   const basePath = pkgRoot ? path.resolve(cwd, pkgRoot) : cwd;
 
   logger.log("Write version %s to package.json in %s", version, basePath);
+  const commandOptions = packageManager === 'npm'
+    ? ["version", version, "--userconfig", npmrc, "--no-git-tag-version", "--allow-same-version"]
+    : ["version", version, "--config", npmrc, "--no-git-tag-version", "--allow-same-version"];
 
   const versionResult = execa(
-    "npm",
-    ["version", version, "--userconfig", npmrc, "--no-git-tag-version", "--allow-same-version"],
+    packageManager,
+    commandOptions,
     {
       cwd: basePath,
       env,
@@ -27,7 +30,10 @@ export default async function (
 
   if (tarballDir) {
     logger.log("Creating npm package version %s", version);
-    const packResult = execa("npm", ["pack", basePath, "--userconfig", npmrc], { cwd, env, preferLocal: true });
+    const commandOptions = packageManager === 'npm'
+      ? ["pack", basePath, "--userconfig", npmrc]
+      : ["pack", basePath, "--config", npmrc];
+    const packResult = execa(packageManager, commandOptions, { cwd, env, preferLocal: true });
     packResult.stdout.pipe(stdout, { end: false });
     packResult.stderr.pipe(stderr, { end: false });
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -20,13 +20,10 @@ export default async function (npmrc, { npmPublish, pkgRoot, packageManager }, p
     const distTag = getChannel(channel);
 
     logger.log(`Publishing version ${version} to npm registry on dist-tag ${distTag}`);
-    const commandOptions = packageManager === 'npm'
-      ? ["publish", basePath, "--userconfig", npmrc, "--tag", distTag, "--registry", registry]
-      : ["publish", basePath, "--config", npmrc, "--tag", distTag, "--registry", registry];
 
     const result = execa(
       packageManager,
-      commandOptions,
+      ["publish", basePath, "--userconfig", npmrc, "--tag", distTag, "--registry", registry],
       { cwd, env, preferLocal: true }
     );
     result.stdout.pipe(stdout, { end: false });

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -4,7 +4,7 @@ import getRegistry from "./get-registry.js";
 import getChannel from "./get-channel.js";
 import getReleaseInfo from "./get-release-info.js";
 
-export default async function (npmrc, { npmPublish, pkgRoot }, pkg, context) {
+export default async function (npmrc, { npmPublish, pkgRoot, packageManager }, pkg, context) {
   const {
     cwd,
     env,
@@ -20,9 +20,13 @@ export default async function (npmrc, { npmPublish, pkgRoot }, pkg, context) {
     const distTag = getChannel(channel);
 
     logger.log(`Publishing version ${version} to npm registry on dist-tag ${distTag}`);
+    const commandOptions = packageManager === 'npm'
+      ? ["publish", basePath, "--userconfig", npmrc, "--tag", distTag, "--registry", registry]
+      : ["publish", basePath, "--config", npmrc, "--tag", distTag, "--registry", registry];
+
     const result = execa(
-      "npm",
-      ["publish", basePath, "--userconfig", npmrc, "--tag", distTag, "--registry", registry],
+      packageManager,
+      commandOptions,
       { cwd, env, preferLocal: true }
     );
     result.stdout.pipe(stdout, { end: false });

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -5,7 +5,7 @@ import getError from "./get-error.js";
 import getRegistry from "./get-registry.js";
 import setNpmrcAuth from "./set-npmrc-auth.js";
 
-export default async function (npmrc, pkg, context) {
+export default async function (npmrc, pkg, context, packageManager) {
   const {
     cwd,
     env: { DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org/", ...env },
@@ -18,7 +18,10 @@ export default async function (npmrc, pkg, context) {
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {
-      const whoamiResult = execa("npm", ["whoami", "--userconfig", npmrc, "--registry", registry], {
+      const commandOptions = packageManager === 'npm'
+        ? ["whoami", "--userconfig", npmrc, "--registry", registry]
+        : ["whoami", "--config", npmrc, "--registry", registry];
+      const whoamiResult = execa(packageManager, commandOptions, {
         cwd,
         env,
         preferLocal: true,

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -18,10 +18,7 @@ export default async function (npmrc, pkg, context, packageManager) {
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {
-      const commandOptions = packageManager === 'npm'
-        ? ["whoami", "--userconfig", npmrc, "--registry", registry]
-        : ["whoami", "--config", npmrc, "--registry", registry];
-      const whoamiResult = execa(packageManager, commandOptions, {
+      const whoamiResult = execa(packageManager, ["whoami", "--userconfig", npmrc, "--registry", registry], {
         cwd,
         env,
         preferLocal: true,

--- a/lib/verify-config.js
+++ b/lib/verify-config.js
@@ -2,15 +2,17 @@ import { isBoolean, isNil, isString } from "lodash-es";
 import getError from "./get-error.js";
 
 const isNonEmptyString = (value) => isString(value) && value.trim();
+const isPackageManager = (value) => value === 'npm' || value === 'pnpm';
 
 const VALIDATORS = {
   npmPublish: isBoolean,
   tarballDir: isNonEmptyString,
   pkgRoot: isNonEmptyString,
+  packageManager: isPackageManager,
 };
 
-export default function ({ npmPublish, tarballDir, pkgRoot }) {
-  const errors = Object.entries({ npmPublish, tarballDir, pkgRoot }).reduce(
+export default function ({ npmPublish, tarballDir, pkgRoot, packageManager }) {
+  const errors = Object.entries({ npmPublish, tarballDir, pkgRoot, packageManager }).reduce(
     (errors, [option, value]) =>
       !isNil(value) && !VALIDATORS[option](value)
         ? [...errors, getError(`EINVALID${option.toUpperCase()}`, { [option]: value })]


### PR DESCRIPTION
Add new `packageManager` option (either `npm` or `pnpm`) which changes the package manager used to publish the package.

Closes #280 