### PR TITLE
fix(deps): raised the minimum accepted range of npm to v10.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^8.0.0",
-        "npm": "^10.0.0",
+        "npm": "^10.5.0",
         "rc": "^1.2.8",
         "read-pkg": "^9.0.0",
         "registry-auth-token": "^5.0.0",
@@ -3929,9 +3929,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.4.0.tgz",
-      "integrity": "sha512-RS7Mx0OVfXlOcQLRePuDIYdFCVBPCNapWHplDK+mh7GDdP/Tvor4ocuybRRPSvfcRb2vjRJt1fHCqw3cr8qACQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.5.0.tgz",
+      "integrity": "sha512-Ejxwvfh9YnWVU2yA5FzoYLTW52vxHCz+MHrOFg9Cc8IFgF/6f5AGPAvb5WTay5DIUP1NIfN3VBZ0cLlGO0Ys+A==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -4004,13 +4004,6 @@
         "which",
         "write-file-atomic"
       ],
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^7.2.1",
@@ -4020,7 +4013,7 @@
         "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.1",
         "@npmcli/run-script": "^7.0.4",
-        "@sigstore/tuf": "^2.3.0",
+        "@sigstore/tuf": "^2.3.1",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^18.0.2",
@@ -4071,7 +4064,7 @@
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
-        "semver": "^7.5.4",
+        "semver": "^7.6.0",
         "spdx-expression-parse": "^3.0.1",
         "ssri": "^10.0.5",
         "supports-color": "^9.4.0",
@@ -4193,7 +4186,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4208,7 +4201,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.3.1",
+      "version": "7.4.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4220,7 +4213,7 @@
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
         "@npmcli/package-json": "^5.0.0",
-        "@npmcli/query": "^3.0.1",
+        "@npmcli/query": "^3.1.0",
         "@npmcli/run-script": "^7.0.2",
         "bin-links": "^4.0.1",
         "cacache": "^18.0.0",
@@ -4254,7 +4247,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.1.0",
+      "version": "8.2.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4413,7 +4406,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "3.0.1",
+      "version": "3.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4448,18 +4441,18 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.3.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "0.2.0",
+      "version": "1.0.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4467,7 +4460,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.2.1",
+      "version": "0.3.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4475,13 +4468,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.2.1",
+      "version": "2.2.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.1",
-        "@sigstore/core": "^0.2.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "make-fetch-happen": "^13.0.0"
       },
       "engines": {
@@ -4489,11 +4482,11 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "tuf-js": "^2.2.0"
       },
       "engines": {
@@ -4501,13 +4494,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "0.1.0",
+      "version": "1.1.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.1",
-        "@sigstore/core": "^0.2.0",
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -4877,7 +4870,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5013,7 +5006,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hasown": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5040,7 +5033,7 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5052,7 +5045,7 @@
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
+      "version": "7.0.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5129,8 +5122,24 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "2.0.0",
-      "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "9.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/npm/node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
@@ -5200,6 +5209,11 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "3.0.1",
       "inBundle": true,
@@ -5247,7 +5261,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.6",
+      "version": "6.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5266,7 +5280,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.7",
+      "version": "7.0.8",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5287,7 +5301,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5322,7 +5336,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.6",
+      "version": "6.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5392,7 +5406,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6001,7 +6015,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6061,16 +6075,16 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.1",
-        "@sigstore/core": "^0.2.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.2.1",
-        "@sigstore/tuf": "^2.3.0",
-        "@sigstore/verify": "^0.1.0"
+        "@sigstore/bundle": "^2.2.0",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.0",
+        "@sigstore/sign": "^2.2.3",
+        "@sigstore/tuf": "^2.3.1",
+        "@sigstore/verify": "^1.1.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -6086,15 +6100,15 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.7.1",
+      "version": "2.8.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 16.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -6121,7 +6135,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
+      "version": "2.5.0",
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
@@ -6135,7 +6149,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.16",
+      "version": "3.0.17",
       "inBundle": true,
       "license": "CC0-1.0"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash-es": "^4.17.21",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^8.0.0",
-    "npm": "^10.0.0",
+    "npm": "^10.5.0",
     "rc": "^1.2.8",
     "read-pkg": "^9.0.0",
     "registry-auth-token": "^5.0.0",


### PR DESCRIPTION
closes semantic-release/semantic-release#3202

even though our existing range allowed anyone to update as soon as the new `npm` version was available, this will encourage being on a version that does not report the `ip` vulnerability a bit more forcefully.