### PR TITLE
ref: Remove usage of aggregate-error library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import { castArray, defaultTo } from "lodash-es";
-import AggregateError from "aggregate-error";
 import { temporaryFile } from "tempy";
 import getPkg from "./lib/get-pkg.js";
 import verifyNpmConfig from "./lib/verify-config.js";

--- a/lib/get-pkg.js
+++ b/lib/get-pkg.js
@@ -1,6 +1,5 @@
 import path from "path";
 import { readPackage } from "read-pkg";
-import AggregateError from "aggregate-error";
 import getError from "./get-error.js";
 
 export default async function ({ pkgRoot }, { cwd }) {

--- a/lib/set-npmrc-auth.js
+++ b/lib/set-npmrc-auth.js
@@ -3,7 +3,6 @@ import rc from "rc";
 import fs from "fs-extra";
 import getAuthToken from "registry-auth-token";
 import nerfDart from "nerf-dart";
-import AggregateError from "aggregate-error";
 import getError from "./get-error.js";
 
 export default async function (npmrc, registry, { cwd, env: { NPM_TOKEN, NPM_CONFIG_USERCONFIG }, logger }) {

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -1,6 +1,5 @@
 import { execa } from "execa";
 import normalizeUrl from "normalize-url";
-import AggregateError from "aggregate-error";
 import getError from "./get-error.js";
 import getRegistry from "./get-registry.js";
 import setNpmrcAuth from "./set-npmrc-auth.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
         "lodash-es": "^4.17.21",
@@ -1690,6 +1689,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
       "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^5.2.0",
@@ -2553,6 +2553,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
       "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "5.0.0"
@@ -3972,6 +3973,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6005,6 +6007,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "dependencies": {
     "@semantic-release/error": "^4.0.0",
-    "aggregate-error": "^5.0.0",
     "execa": "^9.0.0",
     "fs-extra": "^11.0.0",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
ref https://github.com/semantic-release/semantic-release/discussions/3376
ref https://github.com/es-tooling/module-replacements/issues/80

As per the `package.json` `engines` of this package, `@semantic-release/npm` supports Node.js `>=20.8.1`.

As per https://github.com/sindresorhus/aggregate-error

> Note: With [Node.js 15](https://medium.com/@nodejs/node-js-v15-0-0-is-here-deb00750f278), there's now a built-in [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) type.

This means we can remove the usage of this package and use the JavaScript built-in `AggregateError`.