### PR TITLE
fix: respect scoped registries from publishConfig

### DIFF
--- a/lib/get-registry.js
+++ b/lib/get-registry.js
@@ -2,12 +2,15 @@ import path from "path";
 import rc from "rc";
 import getRegistryUrl from "registry-auth-token/registry-url.js";
 
-export default function ({ publishConfig: { registry } = {}, name }, { cwd, env }) {
+export default function ({ publishConfig = {}, name }, { cwd, env }) {
+  const scope = name.split("/")[0];
+  const publishRegistry = publishConfig[`${scope}:registry`] ?? publishConfig.registry;
+
   return (
-    registry ||
+    publishRegistry ||
     env.NPM_CONFIG_REGISTRY ||
     getRegistryUrl(
-      name.split("/")[0],
+      scope,
       rc(
         "npm",
         { registry: "https://registry.npmjs.org/" },

--- a/test/get-registry.test.js
+++ b/test/get-registry.test.js
@@ -39,6 +39,26 @@ test('Get the registry configured in "NPM_CONFIG_REGISTRY"', (t) => {
   );
 });
 
+test('Get the registry configured in "publishConfig" for scoped package', async (t) => {
+  const cwd = temporaryDirectory();
+  await fs.appendFile(path.resolve(cwd, ".npmrc"), "@scope:registry = https://custom3.registry.com");
+  await fs.appendFile(path.resolve(cwd, ".npmrc"), "registry = https://custom4.registry.com");
+
+  t.is(
+    getRegistry(
+      {
+        name: "@scope/package-name",
+        publishConfig: {
+          registry: "https://custom6.registry.com",
+          "@scope:registry": "https://custom5.registry.com",
+        },
+      },
+      { cwd, env: { NPM_CONFIG_REGISTRY: "https://custom1.registry.com/" } }
+    ),
+    "https://custom5.registry.com"
+  );
+});
+
 test('Get the registry configured in ".npmrc" for scoped package', async (t) => {
   const cwd = temporaryDirectory();
   await fs.appendFile(path.resolve(cwd, ".npmrc"), "@scope:registry = https://custom3.registry.com");


### PR DESCRIPTION
This stops a niche issue when using Gitlab registries, where setting the `.npmrc` to pull packages from the instance-wide registry while also setting the `package.json:publishConfig` to push to the project-local registry for a given `@scope` would pass the incorrect `--registry` flag to `npm publish` as well as associate the `NPM_TOKEN` with the wrong URL in the generated userconfig file.

This DOES NOT resolve #219. So `--registry` is still technically ignored for scoped packages. See
[npm/cli#7043](https://github.com/npm/cli/issues/7043) for more details on that.

I made sure not to affect the priority of other resolutions to avoid any breaking changes. An additional test has been added for this specific case.