### PR TITLE
refactor: Change path of publish execution

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -22,8 +22,8 @@ export default async function (npmrc, { npmPublish, pkgRoot }, pkg, context) {
     logger.log(`Publishing version ${version} to npm registry on dist-tag ${distTag}`);
     const result = execa(
       "npm",
-      ["publish", basePath, "--userconfig", npmrc, "--tag", distTag, "--registry", registry],
-      { cwd, env, preferLocal: true }
+      ["publish", "--userconfig", npmrc, "--tag", distTag, "--registry", registry],
+      { cwd: basePath, env, preferLocal: true }
     );
     result.stdout.pipe(stdout, { end: false });
     result.stderr.pipe(stderr, { end: false });


### PR DESCRIPTION
I experienced an issue using this plugin with semantic-release-monorepo. 
When I define the pkfRoot, even though everything is set correctly, the npm cli do not attempt to publish the folder in pkgRoot prop, but the root of the package instead.

`ExecaError: Command failed with exit code 1: npm publish /home/runner/work/bgc-packages/bgc-packages/packages/value-objects/dist --userconfig /tmp/bcb7296253aa364112caea30f087dbce/.npmrc --tag SUS2089 --registry 'https://registry.npmjs.org/'`

As the error above shows, The path is correct at the dist folder, but the npm cli reads from the folder **value-objects**, instead of **value-objects/dist**.
So I read this plugin trying to understand why the prepare command works fine and the publish not, and I found that in prepare command we change de cwd while the publish command we assign the npm cli this responsibility.

This PR changes this. Both commands will now point the current working directory to the path that was given by the config file.
