### PR TITLE
fix(deps): update npm to ^10.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^8.0.0",
-        "npm": "^10.5.0",
+        "npm": "^10.9.3",
         "rc": "^1.2.8",
         "read-pkg": "^9.0.0",
         "registry-auth-token": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash-es": "^4.17.21",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^8.0.0",
-    "npm": "^10.5.0",
+    "npm": "^10.9.3",
     "rc": "^1.2.8",
     "read-pkg": "^9.0.0",
     "registry-auth-token": "^5.0.0",


### PR DESCRIPTION
- closes https://github.com/semantic-release/npm/issues/966

## Situation

- Before the release of [npm@10.9.3](https://github.com/npm/cli/releases/tag/v10.9.3), installing `@semantic-release/npm` reported a low severity vulnerability
- For such existing projects, `npm audit fix` continues to reports that the vulnerability cannot be fixed and refers to https://github.com/advisories/GHSA-v6h2-p8h4-qcjw (CVE-2025-5889 - brace-expansion Regular Expression Denial of Service vulnerability)
- Since the release of [npm@10.9.3](https://github.com/npm/cli/releases/tag/v10.9.3), a new installation of `@semantic-release/npm` reports no vulnerability
- Uninstalling and re-installing `semantic-release` and / or `@semantic-release/npm` also works around the issue

## Change

Update `npm` in package.json dependencies from `^10.5.0` to `^10.9.3`

[npm@10.9.3](https://github.com/npm/cli/releases/tag/v10.9.3) includes the fixed dependency [brace-expansion@2.0.2](https://github.com/juliangruber/brace-expansion/releases/tag/v2.0.2)

## Note

- PR https://github.com/semantic-release/npm/pull/971 only updated the `packageManager` field in [package.json](https://github.com/semantic-release/npm/blob/master/package.json) to `npm@10.9.3` not the `dependencies` field