### PR TITLE
fix(publish-dry-run): temporarily remove the addition of dry-running the publish step

### DIFF
--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -77,8 +77,6 @@ async function verifyTokenAuth(registry, npmrc, context, pkgRoot) {
 
   if (registryIsDefault(registry, DEFAULT_NPM_REGISTRY)) {
     await verifyAuthContextAgainstRegistry(npmrc, registry, context);
-  } else {
-    await attemptPublishDryRun(npmrc, registry, context, pkgRoot);
   }
 }
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -131,7 +131,7 @@ test("Throws error if NPM token is not provided when targeting the default regis
   t.is(error.message, "No npm token specified.");
 });
 
-test("Verify the token with a publish dry-run if the registry configured is not the default one", async (t) => {
+test.skip("Verify the token with a publish dry-run if the registry configured is not the default one", async (t) => {
   const cwd = temporaryDirectory();
   const env = { NPM_TOKEN: "wrong_token" };
   const pkg = { name: "published", version: "1.0.0", publishConfig: { registry: "http://custom-registry.com/" } };

--- a/test/verify-auth.test.js
+++ b/test/verify-auth.test.js
@@ -156,48 +156,45 @@ test.serial(
 
 // since alternative registries are not consistent in implementing `npm whoami`,
 // the best we can attempt to verify is to do a dry run publish and check for auth warnings
-test.serial(
-  "that the token is considered invalid when the publish dry run fails when publishing to a custom registry",
-  async (t) => {
-    const otherRegistry = "https://other.registry.org";
-    const execaResult = Promise.resolve({
-      stderr: ["foo", "bar", "baz", `This command requires you to be logged in to ${otherRegistry}`, "qux"],
-    });
-    execaResult.stderr = { pipe: () => undefined };
-    execaResult.stdout = { pipe: () => undefined };
-    td.when(getRegistry(pkg, context)).thenReturn(otherRegistry);
-    td.when(oidcContextEstablished(otherRegistry, pkg, context)).thenResolve(false);
-    td.when(
-      execa(
-        "npm",
-        [
-          "publish",
-          cwd,
-          "--dry-run",
-          "--tag=semantic-release-auth-check",
-          "--userconfig",
-          npmrc,
-          "--registry",
-          otherRegistry,
-        ],
-        {
-          cwd,
-          env: otherEnvVars,
-          preferLocal: true,
-          lines: true,
-        }
-      )
-    ).thenReturn(execaResult);
+test.skip("that the token is considered invalid when the publish dry run fails when publishing to a custom registry", async (t) => {
+  const otherRegistry = "https://other.registry.org";
+  const execaResult = Promise.resolve({
+    stderr: ["foo", "bar", "baz", `This command requires you to be logged in to ${otherRegistry}`, "qux"],
+  });
+  execaResult.stderr = { pipe: () => undefined };
+  execaResult.stdout = { pipe: () => undefined };
+  td.when(getRegistry(pkg, context)).thenReturn(otherRegistry);
+  td.when(oidcContextEstablished(otherRegistry, pkg, context)).thenResolve(false);
+  td.when(
+    execa(
+      "npm",
+      [
+        "publish",
+        cwd,
+        "--dry-run",
+        "--tag=semantic-release-auth-check",
+        "--userconfig",
+        npmrc,
+        "--registry",
+        otherRegistry,
+      ],
+      {
+        cwd,
+        env: otherEnvVars,
+        preferLocal: true,
+        lines: true,
+      }
+    )
+  ).thenReturn(execaResult);
 
-    const {
-      errors: [error],
-    } = await t.throwsAsync(verifyAuth(npmrc, pkg, {}, context));
+  const {
+    errors: [error],
+  } = await t.throwsAsync(verifyAuth(npmrc, pkg, {}, context));
 
-    t.is(error.name, "SemanticReleaseError");
-    t.is(error.code, "EINVALIDNPMAUTH");
-    t.is(error.message, "Invalid npm authentication.");
-  }
-);
+  t.is(error.name, "SemanticReleaseError");
+  t.is(error.code, "EINVALIDNPMAUTH");
+  t.is(error.message, "Invalid npm authentication.");
+});
 
 test.serial("that errors from setting up auth bubble through this function", async (t) => {
   const registry = DEFAULT_NPM_REGISTRY;


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/travi'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/travi/tally.svg'></a>

since it fails when run from the `verifyConditions` hook because the version has not yet been changed and conflicts with the existing published version

our existing tests for this plugin do not simulate a tag already existing, so we need to add that context to our tests before re-introducing this feature. this went beyond what was necessary for trusted publishing, so backing this part back out in order to clear the way for trusted publishing without introducing new errors for folks