### PR TITLE
fix(deps): update npm to ^11.8.0 to fix tar vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^8.0.0",
-        "npm": "^11.6.2",
+        "npm": "^11.8.0",
         "rc": "^1.2.8",
         "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash-es": "^4.17.21",
     "nerf-dart": "^1.0.0",
     "normalize-url": "^8.0.0",
-    "npm": "^11.6.2",
+    "npm": "^11.8.0",
     "rc": "^1.2.8",
     "read-pkg": "^10.0.0",
     "registry-auth-token": "^5.0.0",


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/karlderkaefer'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/karlderkaefer/tally.svg'></a>

Hi we have a high security finding on semantic-release for `tar 7.5.2`. The problem is by default it pulls semantic-release/npm which used npm dependency. lets upgrade to fix the vulnerability 

## Summary

This updates the npm dependency from `^11.6.2` to `^11.8.0` to address the high severity vulnerability in tar ([GHSA-8qq5-rm4j-mr97](https://github.com/advisories/GHSA-8qq5-rm4j-mr97)).

### Vulnerability Details

The `tar` package bundled in npm versions <= 11.7.0 is vulnerable to:
- **Arbitrary File Overwrite** via insufficient path sanitization
- **Symlink Poisoning** attacks

### Version Analysis

| npm version | bundled tar | status |
|-------------|-------------|--------|
| 11.7.0 | ^7.5.2 | ❌ Vulnerable |
| 11.8.0 | ^7.5.4 | ✅ Fixed |
| 11.9.0 | ^7.5.7 | ✅ Latest |

### Changes

- Updated `npm` dependency from `^11.6.2` to `^11.8.0`
- Updated `package-lock.json`

### Testing

- `npm audit` returns 0 vulnerabilities after this change
- All existing tests should pass (no functional changes)

## Test plan

- [ ] CI passes
- [ ] `npm audit` shows no vulnerabilities related to tar