### PR TITLE
fix(deps): override picomatch to >=4.0.4 (CVE-2026-33671)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
     "strip-ansi": "7.2.0",
     "testdouble": "3.20.2"
   },
+  "overrides": {
+    "npm": {
+      "picomatch": ">=4.0.4"
+    }
+  },
   "engines": {
     "node": "^22.14.0 || >= 24.10.0"
   },


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/starlightromero'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/starlightromero/tally.svg'></a>

## Summary

Add npm overrides to force `picomatch>=4.0.4` resolution for the bundled `npm` dependency, fixing **CVE-2026-33671** (high severity ReDoS via crafted extglob patterns in picomatch 4.0.0–4.0.3).

## Problem

Installing `@semantic-release/npm@13.1.5` reports a high severity vulnerability for `picomatch@4.0.3` bundled inside `npm@11.12.1` (via `node-gyp` → `tinyglobby`). The vulnerability cannot be resolved with `npm audit fix` because `npm` bundles its own dependencies.

```
# npm audit report

picomatch  4.0.0 - 4.0.3
Severity: high
Picomatch: Regular Expression Denial of Service via crafted extglob patterns
fix available via `npm audit fix`
node_modules/npm/node_modules/tinyglobby/node_modules/picomatch

1 high severity vulnerability
```

## Fix

Adds an `overrides` field to `package.json` that forces `picomatch>=4.0.4` resolution within the `npm` dependency tree:

```json
"overrides": {
  "npm": {
    "picomatch": ">=4.0.4"
  }
}
```

## References

- [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj)
- [CVE-2026-33671](https://nvd.nist.gov/vuln/detail/CVE-2026-33671)
- [picomatch 4.0.4 release](https://github.com/micromatch/picomatch/releases/tag/4.0.4)

Closes #1129