### PR TITLE
chore(deps): remove `aggregate-error` polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import { castArray, defaultTo } from "lodash-es";
-import AggregateError from "aggregate-error";
 import { temporaryFile } from "tempy";
 import getPkg from "./lib/get-pkg.js";
 import verifyNpmConfig from "./lib/verify-config.js";

--- a/lib/get-pkg.js
+++ b/lib/get-pkg.js
@@ -1,6 +1,5 @@
 import path from "path";
 import { readPackage } from "read-pkg";
-import AggregateError from "aggregate-error";
 import getError from "./get-error.js";
 
 export default async function ({ pkgRoot }, { cwd }) {

--- a/lib/set-npmrc-auth.js
+++ b/lib/set-npmrc-auth.js
@@ -3,7 +3,6 @@ import rc from "rc";
 import fs from "fs-extra";
 import getAuthToken from "registry-auth-token";
 import nerfDart from "nerf-dart";
-import AggregateError from "aggregate-error";
 import getError from "./get-error.js";
 import { OFFICIAL_REGISTRY } from "./definitions/constants.js";
 

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -1,6 +1,5 @@
 import { execa } from "execa";
 import normalizeUrl from "normalize-url";
-import AggregateError from "aggregate-error";
 import getRegistry from "./get-registry.js";
 import setNpmrcAuth from "./set-npmrc-auth.js";
 import getError from "./get-error.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
@@ -1329,7 +1328,6 @@
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
@@ -1357,7 +1356,6 @@
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
-        "aggregate-error": "^5.0.0",
         "env-ci": "^11.2.0",
         "execa": "^9.0.0",
         "fs-extra": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@actions/core": "^3.0.0",
     "@semantic-release/error": "^4.0.0",
-    "aggregate-error": "^5.0.0",
     "env-ci": "^11.2.0",
     "execa": "^9.0.0",
     "fs-extra": "^11.0.0",

--- a/test/verify-auth.test.js
+++ b/test/verify-auth.test.js
@@ -1,6 +1,5 @@
 import test from "ava";
 import * as td from "testdouble";
-import AggregateError from "aggregate-error";
 import { OFFICIAL_REGISTRY } from "../lib/definitions/constants.js";
 
 let execa, verifyAuth, getRegistry, setNpmrcAuth, oidcContextEstablished;


### PR DESCRIPTION
Removes `aggregate-error` dependency

`AggregateError` is available natively since Node 15.0.0
