### PR TITLE
feat(trusted-publishing): add support for CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ id_tokens:
 
 See the [npm documentation for more details about configuring pipeline details](https://docs.npmjs.com/trusted-publishers#gitlab-cicd-configuration)
 
+#### Trusted publishing for CircleCI
+
+To leverage trusted publishing and publish with provenance from CircleCI, follow the official guide from CircleCI, no additional configuration is required.
+
+Refer to [Publish to npm using OIDC trusted publishing - CircleCI Docs](https://circleci.com/docs/guides/deploy/deploy-to-npm-registry) for more details.
+
 #### Unsupported CI providers
 
 Token authentication is **required** and can be set via [environment variables](#environment-variables).

--- a/lib/definitions/constants.js
+++ b/lib/definitions/constants.js
@@ -2,3 +2,4 @@ export const OFFICIAL_REGISTRY = "https://registry.npmjs.org/";
 
 export const GITHUB_ACTIONS_PROVIDER_NAME = "GitHub Actions";
 export const GITLAB_PIPELINES_PROVIDER_NAME = "GitLab CI/CD";
+export const CIRCLECI_PROVIDER_NAME = "CircleCI";

--- a/lib/trusted-publishing/token-exchange.js
+++ b/lib/trusted-publishing/token-exchange.js
@@ -1,8 +1,13 @@
 import { getIDToken } from "@actions/core";
 import envCi from "env-ci";
+import { promisify } from "util";
+import { exec } from "child_process";
+
+const execAsync = promisify(exec);
 
 import {
   OFFICIAL_REGISTRY,
+  CIRCLECI_PROVIDER_NAME,
   GITHUB_ACTIONS_PROVIDER_NAME,
   GITLAB_PIPELINES_PROVIDER_NAME,
 } from "../definitions/constants.js";
@@ -57,6 +62,18 @@ async function exchangeGitlabPipelinesToken(packageName, logger) {
   return exchangeIdToken(idToken, packageName, logger);
 }
 
+async function exchangeCircleCIToken(packageName, logger) {
+  const idToken = process.env.NPM_ID_TOKEN;
+
+  logger.log("Verifying OIDC context for publishing from CircleCI");
+
+  if (!idToken) {
+    return undefined;
+  }
+
+  return exchangeIdToken(idToken, packageName, logger);
+}
+
 export default function exchangeToken(pkg, { logger }) {
   const { name: ciProviderName } = envCi();
 
@@ -66,6 +83,10 @@ export default function exchangeToken(pkg, { logger }) {
 
   if (GITLAB_PIPELINES_PROVIDER_NAME === ciProviderName) {
     return exchangeGitlabPipelinesToken(pkg.name, logger);
+  }
+
+  if (CIRCLECI_PROVIDER_NAME === ciProviderName) {
+    return exchangeCircleCIToken(pkg.name, logger);
   }
 
   return undefined;

--- a/test/trusted-publishing/token-exchange.test.js
+++ b/test/trusted-publishing/token-exchange.test.js
@@ -3,6 +3,7 @@ import * as td from "testdouble";
 
 import {
   OFFICIAL_REGISTRY,
+  CIRCLECI_PROVIDER_NAME,
   GITHUB_ACTIONS_PROVIDER_NAME,
   GITLAB_PIPELINES_PROVIDER_NAME,
 } from "../../lib/definitions/constants.js";
@@ -93,6 +94,42 @@ test.serial("that `undefined` is returned when ID token is not available on GitL
 test.serial("that `undefined` is returned when token exchange fails on GitLab Pipelines", async (t) => {
   process.env.NPM_ID_TOKEN = idToken;
   td.when(envCi()).thenReturn({ name: GITLAB_PIPELINES_PROVIDER_NAME });
+  td.when(
+    fetch(`${OFFICIAL_REGISTRY}-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(packageName)}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${idToken}` },
+    })
+  ).thenResolve(
+    new Response(JSON.stringify({ message: "foo" }), { status: 401, headers: { "Content-Type": "application/json" } })
+  );
+
+  t.is(await exchangeToken(pkg, { logger }), undefined);
+});
+
+test.serial("that an access token is returned when token exchange succeeds on CircleCI", async (t) => {
+  process.env.NPM_ID_TOKEN = idToken;
+  td.when(envCi()).thenReturn({ name: CIRCLECI_PROVIDER_NAME });
+  td.when(
+    fetch(`${OFFICIAL_REGISTRY}-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(packageName)}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${idToken}` },
+    })
+  ).thenResolve(
+    new Response(JSON.stringify({ token }), { status: 201, headers: { "Content-Type": "application/json" } })
+  );
+
+  t.is(await exchangeToken(pkg, { logger }), token);
+});
+
+test.serial("that `undefined` is returned when ID token is not available on CircleCI", async (t) => {
+  td.when(envCi()).thenReturn({ name: CIRCLECI_PROVIDER_NAME });
+
+  t.is(await exchangeToken(pkg, { logger }), undefined);
+});
+
+test.serial("that `undefined` is returned when token exchange fails on CircleCI", async (t) => {
+  process.env.NPM_ID_TOKEN = idToken;
+  td.when(envCi()).thenReturn({ name: CIRCLECI_PROVIDER_NAME });
   td.when(
     fetch(`${OFFICIAL_REGISTRY}-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(packageName)}`, {
       method: "POST",


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/Thomaash'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/Thomaash/tally.svg'></a>

Fixes #1121.
Unlike #1122, doesn't make any assumptions about future reusability.

I also verified it by releasing a new version of my old vuex-ltm package:
- code: https://github.com/Thomaash/vuex-ltm/commit/33c324b2bb6471e5c6748d7cf17dbd14794dbed4
- job: https://app.circleci.com/pipelines/github/Thomaash/vuex-ltm/16534/details?workflowId=eb25f9af-6cca-4021-9611-7dcba27b2501&job=2d6b6ada-980e-4823-85e7-3854417a10cd&buildNumber=59797&jobType=build#step-103-