### PR TITLE
Security: NPM_TOKEN written to .npmrc file without restricted permissions

### DIFF
--- a/lib/set-npmrc-auth.js
+++ b/lib/set-npmrc-auth.js
@@ -31,6 +31,7 @@ export default async function (npmrc, registry, { cwd, env: { NPM_TOKEN, NPM_CON
       npmrc,
       `${currentConfig ? `${currentConfig}\n` : ""}${nerfDart(registry)}:_authToken = \${NPM_TOKEN}`
     );
+    await fs.chmod(npmrc, 0o600);
     logger.log(`Wrote NPM_TOKEN to ${npmrc}`);
   } else {
     throw new AggregateError([getError("ENONPMTOKEN", { registry })]);


### PR DESCRIPTION
<!-- added by https://github.com/apps/hearts --><a href='https://hearts.dev/projects/3/users/tomaioo'><img width='50' alt='' align='right' src='https://hearts.dev/projects/3/users/tomaioo/tally.svg'></a>

## Summary

Security: NPM_TOKEN written to .npmrc file without restricted permissions

## Problem

**Severity**: `Medium` | **File**: `lib/set-npmrc-auth.js:L36`

In `lib/set-npmrc-auth.js`, the `NPM_TOKEN` environment variable is written to a temporary `.npmrc` file using `fs.outputFile`. This function creates files with default permissions (typically 0644), meaning the file is world-readable. If the CI environment is shared or another user/process can read the temporary directory, the npm authentication token could be exposed.

## Solution

Set restrictive file permissions (e.g., 0600) when writing the `.npmrc` file to ensure only the owner can read it. You can achieve this by writing the file with `fs.writeFile` and then using `fs.chmod`, or by using a library that supports permission modes.

## Changes

- `lib/set-npmrc-auth.js` (modified)